### PR TITLE
Handle groups of VCards correctly

### DIFF
--- a/Whatsapp_Chat_Exporter/extract_iphone.py
+++ b/Whatsapp_Chat_Exporter/extract_iphone.py
@@ -4,6 +4,7 @@ import os
 from glob import glob
 from pathlib import Path
 from mimetypes import MimeTypes
+from markupsafe import escape as htmle
 from Whatsapp_Chat_Exporter.data_model import ChatStore, Message
 from Whatsapp_Chat_Exporter.utility import APPLE_TIME, Device
 
@@ -282,10 +283,12 @@ def vcard(db, data, media_folder):
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write(vcard_string)
 
-        vcard_summary = " + ".join([f"{name} (See file: {os.path.basename(fp)})" for name, fp in zip(vcard_names, file_paths)])
+        vcard_summary = "This media include the following vCard file(s):<br>" 
+        vcard_summary += " | ".join([f'<a href="{htmle(fp)}">{htmle(name)}</a>' for name, fp in zip(vcard_names, file_paths)])
         message = data[content["_id"]].messages[content["ZMESSAGE"]]
         message.data = vcard_summary
         message.mime = "text/x-vcard"
         message.media = True
         message.meta = True
+        message.safe = True
         print(f"Processing vCards...({index + 1}/{total_row_number})", end="\r")


### PR DESCRIPTION
A  VCard in a message can sometimes be a group of VCards in which case ZVCARDNAME contains a list of VCard names separated by `"_$!<Name-Separator>!$_"`. Note that the first element is the name of the group and is currently dismissed.
ZVCARDSTRING contain the list of VCards separated by `"_$!<VCard-Separator>!$_"`.

Currently the program crashes because it tries to create a Vcard named using a potentially ultra long name (I have groups of hundreds of VCards). This code now handles those groups correctly and saves each VCard in its own VCF file.

You might wanna adjust the content of message.data to your liking as it currently just provide a basic list of the VCards:
"Contact 1 (See file: Contact1.vcf) + Contact 2 (See file: Contact2.vcf)".

Given the path to the VCard can be quite long, I thought you might want to use my format and create a URL link to the actual VCard?

Here is an example:
‎ZVCARDNAME = 
`2 contacts_$!<Name-Separator>!$_Contact 1_$!<Name-Separator>!$_Contact 2`
ZVCARDSTRING = 
```
BEGIN:VCARD
VERSION:3.0
N:Contact;1;;;
FN:Contact 1
TEL;type=CELL;type=VOICE;waid=11231231234:+1 (123) 123-1234
END:VCARD_$!<VCard-Separator>!$_BEGIN:VCARD
VERSION:3.0
N:Contact;1;;;
FN:Contact 2
ORG:Conty;
TEL;type=CELL;type=VOICE;waid=11231231234:+1 (123) 123-1234
item1.ADR;type=HOME:;;1234 Test Ct.;NYC;NY;Blah;United States
item1.X-ABADR:us
END:VCARD
```