### PR TITLE
Support for incremental merges of two export folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ options:
   --call-db [CALL_DB_IOS]
                         Path to call database (default: 1b432994e958845fffe8e2f190f26d1511534088) iOS only
   --headline HEADLINE   The custom headline for the HTML output. Use '??' as a placeholder for the chat name
+  --incremental-merge   Performs an incremental merge of two exports. Requires setting both --source-dir and --target-dir.
+                        The chats (JSON files only) and media from the source directory will be merged into the target
+                        directory. No chats or media will be deleted from the target directory, only new chats and media
+                        will be added to it.
+  --source-dir SOURCE_DIR
+                        Sets the source directory. Used for performing incremental merges.
+  --target-dir TARGET_DIR
+                        Sets the target directory. Used for performing incremental merges.
 
 WhatsApp Chat Exporter: 0.11.2 Licensed with MIT. See https://wts.knugi.dev/docs?dest=osl for all open source
 licenses.

--- a/Whatsapp_Chat_Exporter/__main__.py
+++ b/Whatsapp_Chat_Exporter/__main__.py
@@ -364,7 +364,7 @@ def main():
         parser.error("You can only use --import with -j and without --no-html, -a, -i, -e.")
     elif args.import_json and not os.path.isfile(args.json):
         parser.error("JSON file not found.")
-    if args.incremental_merge and args.source_dir is None or args.target_dir is None:
+    if args.incremental_merge and (args.source_dir is None or args.target_dir is None):
         parser.error("You must specify both --source-dir and --target-dir for incremental merge.")
     if args.android and args.business:
         parser.error("WhatsApp Business is only available on iOS for now.")

--- a/Whatsapp_Chat_Exporter/__main__.py
+++ b/Whatsapp_Chat_Exporter/__main__.py
@@ -326,10 +326,11 @@ def main():
         dest="incremental_merge",
         default=False,
         action='store_true',
-        help=("Performs an incremental merge of two exports."
-              "Requires setting both --source-dir and --target-dir."
-              "The chats and media of the source directory will be merged into the target directory."
-              "No chats or media will be deleted from the target directory, only new chats and media will be added to it."
+        help=("Performs an incremental merge of two exports. "
+              "Requires setting both --source-dir and --target-dir. "
+              "The chats (JSON files only) and media from the source directory will be merged into the target directory. "
+              "No chat messages or media will be deleted from the target directory; only new chat messages and media will be added to it. "
+              "This enables chat messages and media to be deleted from the device to free up space, while ensuring they are preserved in the exported backups."
         )
     )
     parser.add_argument(

--- a/Whatsapp_Chat_Exporter/data_model.py
+++ b/Whatsapp_Chat_Exporter/data_model.py
@@ -57,11 +57,38 @@ class ChatStore():
             'messages': serialized_msgs
         }
 
+    @classmethod
+    def from_json(cls, data):
+        chat = cls(data.get("type"), data.get("name"))
+        chat.my_avatar = data.get("my_avatar")
+        chat.their_avatar = data.get("their_avatar")
+        chat.their_avatar_thumb = data.get("their_avatar_thumb")
+        chat.status = data.get("status")
+        for id, msg_data in data.get("messages", {}).items():
+            message = Message.from_json(msg_data)
+            chat.add_message(id, message)
+        return chat
+
     def get_last_message(self):
         return tuple(self.messages.values())[-1]
 
     def get_messages(self):
         return self.messages.values()
+
+    def merge_with(self, other):
+        if not isinstance(other, ChatStore):
+            raise TypeError("Can only merge with another ChatStore object")
+        
+        # Update fields if they are not None in the other ChatStore
+        self.name = other.name or self.name
+        self.type = other.type or self.type
+        self.my_avatar = other.my_avatar or self.my_avatar
+        self.their_avatar = other.their_avatar or self.their_avatar
+        self.their_avatar_thumb = other.their_avatar_thumb or self.their_avatar_thumb
+        self.status = other.status or self.status
+        
+        # Merge messages
+        self.messages.update(other.messages)
 
 
 class Message():
@@ -107,3 +134,24 @@ class Message():
             'thumb'       : self.thumb,
             'sticker'     : self.sticker
         }
+
+    @classmethod
+    def from_json(cls, data):
+        message = cls(
+            data["from_me"],
+            data["timestamp"],
+            data["time"],
+            data["key_id"]
+        )
+        message.media = data.get("media")
+        message.meta = data.get("meta")
+        message.data = data.get("data")
+        message.sender = data.get("sender")
+        message.safe = data.get("safe")
+        message.mime = data.get("mime")
+        message.reply = data.get("reply")
+        message.quoted_data = data.get("quoted_data")
+        message.caption = data.get("caption")
+        message.thumb = data.get("thumb")
+        message.sticker = data.get("sticker")
+        return message

--- a/Whatsapp_Chat_Exporter/utility.py
+++ b/Whatsapp_Chat_Exporter/utility.py
@@ -9,6 +9,7 @@ from markupsafe import Markup
 from datetime import datetime, timedelta
 from enum import IntEnum
 from Whatsapp_Chat_Exporter.data_model import ChatStore
+import shutil
 try:
     from enum import StrEnum, IntEnum
 except ImportError:
@@ -201,6 +202,58 @@ def import_from_json(json_file, data):
             chat.add_message(id, message)
         data[jid] = chat
         print(f"Importing chats from JSON...({index + 1}/{total_row_number})", end="\r")
+
+
+def incremental_merge(source_dir: str, target_dir: str, media_dir: str):
+    json_files = [f for f in os.listdir(source_dir) if f.endswith('.json')]
+    print("JSON files found:", json_files)
+    
+    for json_file in json_files:
+        source_path = os.path.join(source_dir, json_file)
+        target_path = os.path.join(target_dir, json_file)
+        
+        if not os.path.exists(target_path):
+            print(f"Copying {json_file} to target directory...")
+            os.makedirs(target_dir, exist_ok=True)
+            with open(source_path, 'rb') as src, open(target_path, 'wb') as dst:
+                dst.write(src.read())
+        else:
+            print(f"Merging {json_file} with existing file in target directory...")
+            with open(source_path, 'r') as src_file, open(target_path, 'r') as tgt_file:
+                source_data = json.load(src_file)
+                target_data = json.load(tgt_file)
+                
+                # Parse JSON into ChatStore objects using from_json()
+                source_chats = {jid: ChatStore.from_json(chat) for jid, chat in source_data.items()}
+                target_chats = {jid: ChatStore.from_json(chat) for jid, chat in target_data.items()}
+                
+                # Merge chats using merge_with()
+                for jid, chat in source_chats.items():
+                    if jid in target_chats:
+                        target_chats[jid].merge_with(chat)
+                    else:
+                        target_chats[jid] = chat
+                
+                # Write merged data back to the target file
+                with open(target_path, 'w') as merged_file:
+                    merged_data = {jid: chat.to_json() for jid, chat in target_chats.items()}
+                    json.dump(merged_data, merged_file, indent=2)
+
+    # Merge media directories
+    source_media_path = os.path.join(source_dir, media_dir)
+    target_media_path = os.path.join(target_dir, media_dir)
+    if os.path.exists(source_media_path):
+        for root, dirs, files in os.walk(source_media_path):
+            relative_path = os.path.relpath(root, source_media_path)
+            target_root = os.path.join(target_media_path, relative_path)
+            os.makedirs(target_root, exist_ok=True)
+            for file in files:
+                source_file = os.path.join(root, file)
+                target_file = os.path.join(target_root, file)
+                # we only copy if the file doesn't exist in the target or if the source is newer
+                if not os.path.exists(target_file) or os.path.getmtime(source_file) > os.path.getmtime(target_file):
+                    print(f"Copying {source_file} to {target_file}...")
+                    shutil.copy2(source_file, target_file)
 
 
 def sanitize_filename(file_name: str):


### PR DESCRIPTION
## Description of Changes
This PR adds support for incremental merges of two export folders.

One of the limitations of this tool is that if we delete messages and media from the device, they will be missing from the next export, and thus lost.
Incremental merges address this problem by merging two export folders, adding only new changes while preserving all existing data in the target folder. No messages or media in the target folder will ever be deleted.

Note that only JSON files and media are merged - the HTML files are left untouched.
This is by design because the JSON files have a stable format and are a better representation of the chat data.

This also means that outputting JSON is a requirement for using the incremental merge feature.

The `--incremental-merge` option is meant to be used _after_ performing a regular export first, as it needs both the original export folder and the new one.

I tried to keep the help description of `--incremental-merge` as clear as possible (despite a bit verbose).