### PR TITLE
Convert string to int before size comparison

### DIFF
--- a/.github/generate-website.js
+++ b/.github/generate-website.js
@@ -32,6 +32,13 @@ const generateHTML = (content) =>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="title" content="WhatsApp Chat Exporter">
+    <meta name="description" content="Export your WhatsApp conversations from Android and iOS/iPadOS devices to HTML, JSON, or text formats. Supports encrypted backups (Crypt12, Crypt14, Crypt15) and customizable templates.">
+    <meta name="keywords" content="WhatsApp, WhatsApp Chat Exporter, WhatsApp export tool, WhatsApp backup decryption, Crypt12, Crypt14, Crypt15, WhatsApp database parser, WhatsApp chat history, HTML export, JSON export, text export, customizable templates, media handling, vCard import, Python tool, open source, MIT license">
+    <meta name="robots" content="index, follow">
+    <meta name="author" content="KnugiHK">
+    <meta name="license" content="MIT">
+    <meta name="generator" content="Python">
     <title>WhatsApp Chat Exporter</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <style>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Important Note
 
-**All PRs (except for changes unrelated to source files) should target the `dev` branch.**
+**All PRs (except for changes unrelated to source files) should target and start from the `dev` branch.**
 
 ## Related Issue
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,11 @@
+# Important Note
+
+**All PRs (except for changes unrelated to source files) should target the `dev` branch.**
+
 ## Related Issue
-- Please reference the related issue here (e.g., `Fixes #123` or `Closes #456`), if there are any.
+
+- Please put a reference to the related issue here (e.g., `Fixes #123` or `Closes #456`), if there are any.
 
 ## Description of Changes
-- Briefly describe the changes made in this PR. Explain the purpose, the implementation details, and any important information that reviewers should be aware of.
 
-## Important (Please remove this section before submitting the PR)
-- Before submitting this PR, please make sure to look at **[this issue](https://github.com/KnugiHK/WhatsApp-Chat-Exporter/issues/137)**. It contains crucial context and discussion that may affect the changes in this PR.
+- Briefly describe the changes made in this PR. Explain the purpose, the implementation details, and any important information that reviewers should be aware of.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,100 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main", "dev" ]
+  pull_request:
+    branches: [ "main", "dev" ]
+  schedule:
+    - cron: '25 21 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: python
+          build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Add any setup steps before running the `github/codeql-action/init` action.
+    # This includes steps like installing compilers or runtimes (`actions/setup-node`
+    # or others). This is typically only required for manual builds.
+    # - name: Setup runtime (example)
+    #   uses: actions/setup-example@v1
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -30,7 +30,9 @@ jobs:
         run: npm install marked fs-extra marked-alert
       
       - name: Generate website from README
-        run: node .github/generate-website.js
+        run: |
+          node .github/generate-website.js
+          echo 'wts.knugi.dev' > ./docs/CNAME
       
       - name: Deploy to gh-pages
         if: github.ref == 'refs/heads/main'  # Ensure deployment only happens from main

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2023 Knugi
+Copyright (c) 2021-2025 Knugi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.django
+++ b/LICENSE.django
@@ -1,9 +1,5 @@
 The Whatsapp Chat Exporter is licensed under the MIT license. For more information,
-refer to the file LICENSE.
-
-Whatsapp Chat Exporter incorporates code from Django, governed by the three-clause
-BSD license—a permissive open-source license. The copyright and license details are
-provided below to adhere to Django's terms.
+refer to https://github.com/KnugiHK/WhatsApp-Chat-Exporter/wiki/Open-Source-Licenses.
 
 ------
 

--- a/README.md
+++ b/README.md
@@ -245,10 +245,6 @@ WhatsApp Chat Exporter: 0.12.0 Licensed with MIT. See https://wts.knugi.dev/docs
 licenses.
 ```
 
-# To do
-
-See [issues](https://github.com/KnugiHK/Whatsapp-Chat-Exporter/issues).
-
 # Legal Stuff & Disclaimer
 
 This is a MIT licensed project.

--- a/Whatsapp_Chat_Exporter/android_handler.py
+++ b/Whatsapp_Chat_Exporter/android_handler.py
@@ -998,7 +998,7 @@ def _generate_paginated_chat(current_chat, safe_file_name, name, contact, output
         else:
             current_size += ROW_SIZE + 100  # Assume media and meta HTML are 100 bytes
             
-        if current_size > maximum_size:
+        if current_size > int(maximum_size):
             # Create a new page
             output_file_name = f"{output_folder}/{safe_file_name}-{current_page}.html"
             rendering(


### PR DESCRIPTION
This commit fixes a TypeError that occurred when comparing current_size (an integer) with maximum_size (a string). Python does not allow comparison between int and str types using the > operator, which caused the application to crash during execution.

To resolve this, maximum_size is now explicitly cast to an integer before the comparison. This ensures that both values are of the same type and that the size check works as expected.

# Important Note

**All PRs (except for changes unrelated to source files) should target and start from the `dev` branch.**

## Related Issue

- Please put a reference to the related issue here (e.g., `Fixes #123` or `Closes #456`), if there are any.

## Description of Changes

- Briefly describe the changes made in this PR. Explain the purpose, the implementation details, and any important information that reviewers should be aware of.
