### PR TITLE
Add support for telegram JSON file format

### DIFF
--- a/Whatsapp_Chat_Exporter/__main__.py
+++ b/Whatsapp_Chat_Exporter/__main__.py
@@ -690,12 +690,12 @@ def export_multiple_json(args, data: Dict) -> None:
             contact = jik.replace('+', '')
 
         if args.telegram:
-            obj = telegram_json_format(jik, data[jik])
+            messages = telegram_json_format(jik, data[jik], args.timezone_offset)
         else:
-            obj = {jik: data[jik]}
+            messages = {jik: data[jik]}
         with open(f"{json_path}/{safe_name(contact)}.json", "w") as f:
             file_content = json.dumps(
-                obj,
+                messages,
                 ensure_ascii=not args.avoid_encoding_json,
                 indent=args.pretty_print_json
             )


### PR DESCRIPTION
Add the --telegram command line argument that, combined with a JSON output,
generates a Telegram compatible JSON file [1].

The JSON is per-chat, so the --telegram argument implies the --json-per-chat setting.

I took a few shortcuts:
* Contact and Ids are inferred from the chat id or phone numbers
* All text is marked as plain (e.g. no markup or different types)
* Only personal chats and private groups supported
* Private groups are defined if the chat has a name
* Various ids try to match the ones in WA but may require bulk edits

[1] - https://core.telegram.org/import-export

Fixes: https://github.com/KnugiHK/WhatsApp-Chat-Exporter/issues/152