### PR TITLE
Fix some missing vcard names

### DIFF
--- a/Whatsapp_Chat_Exporter/android_handler.py
+++ b/Whatsapp_Chat_Exporter/android_handler.py
@@ -75,9 +75,15 @@ def messages(db, data, media_folder, timezone_offset, filter_date, filter_chat, 
     logger.info(f"Processing messages...(0/{total_row_number})\r")
 
     try:
-        content_cursor, table_message = _get_messages_cursor(c, filter_empty, filter_date, filter_chat)
-    except Exception as e:
-        raise e
+        content_cursor = _get_messages_cursor_legacy(c, filter_empty, filter_date, filter_chat)
+        table_message = False
+    except sqlite3.OperationalError as e:
+        logger.debug(f'Got sql error "{e}" in _get_message_cursor_legacy trying fallback.\n')
+        try:
+            content_cursor = _get_messages_cursor_new(c, filter_empty, filter_date, filter_chat)
+            table_message = True
+        except Exception as e:
+            raise e
 
     i = 0
     # Fetch the first row safely
@@ -144,18 +150,6 @@ def _get_message_count(cursor, filter_empty, filter_date, filter_chat):
                         {exclude_filter}""")
     return cursor.fetchone()[0]
 
-def _get_messages_cursor(c, filter_empty, filter_date, filter_chat):
-    try:
-        return _get_messages_cursor_legacy(c, filter_empty, filter_date, filter_chat), False
-    except sqlite3.OperationalError as e:
-        logger.debug(f'Got sql error "{e}" in _get_messages_cursor_legacy trying fallback.\n')
-
-    try:
-        return _get_messages_cursor_v3(c, filter_empty, filter_date, filter_chat), True
-    except sqlite3.OperationalError as e:
-        logger.debug(f'Got sql error "{e}" in _get_messages_cursor_v3 trying fallback.\n')
-
-    return _get_messages_cursor_new(c, filter_empty, filter_date, filter_chat), True
 
 def _get_messages_cursor_legacy(cursor, filter_empty, filter_date, filter_chat):
     """Get cursor for legacy database schema."""
@@ -221,18 +215,8 @@ def _get_messages_cursor_legacy(cursor, filter_empty, filter_date, filter_chat):
                     ORDER BY messages.timestamp ASC;""")
     return cursor
 
-def _get_messages_cursor_v3(cursor, filter_empty, filter_date, filter_chat):
-    """Get cursor for new database schema with a join to jd_map to get the phone number of randomized JIDs."""
-    append_fields = "COALESCE(jid_unrand.raw_string, jid_group.raw_string) as group_sender_jid"
 
-    append_joins = f""" LEFT JOIN jid_map jid_map_unrand
-                            ON jid_map_unrand.lid_row_id = message.sender_jid_row_id
-                        LEFT JOIN jid jid_unrand
-                            ON jid_unrand._id = jid_map_unrand.jid_row_id"""
-
-    return _get_messages_cursor_new(cursor, filter_empty, filter_date, filter_chat, append_fields, append_joins)
-
-def _get_messages_cursor_new(cursor, filter_empty, filter_date, filter_chat, append_fields = None, append_joins = None):
+def _get_messages_cursor_new(cursor, filter_empty, filter_date, filter_chat):
     """Get cursor for new database schema."""
     empty_filter = get_cond_for_empty(filter_empty, "key_remote_jid", "broadcast")
     date_filter = f'AND message.timestamp {filter_date}' if filter_date is not None else ''
@@ -240,12 +224,6 @@ def _get_messages_cursor_new(cursor, filter_empty, filter_date, filter_chat, app
         filter_chat[0], True, ["key_remote_jid", "jid_group.raw_string"], "jid_global", "android")
     exclude_filter = get_chat_condition(
         filter_chat[1], False, ["key_remote_jid", "jid_group.raw_string"], "jid_global", "android")
-
-    if not append_fields:
-        append_fields = "jid_group.raw_string as group_sender_jid"
-
-    if not append_joins:
-        append_joins = ""
 
     cursor.execute(f"""SELECT jid_global.raw_string as key_remote_jid,
                             message._id,
@@ -262,6 +240,7 @@ def _get_messages_cursor_new(cursor, filter_empty, filter_date, filter_chat, app
                             message.key_id,
                             message_quoted.text_data as quoted_data,
                             message.message_type as media_wa_type,
+                            jid_group.raw_string as group_sender_jid,
                             chat.subject as chat_subject,
                             missed_call_logs.video_call,
                             message.sender_jid_row_id,
@@ -271,8 +250,7 @@ def _get_messages_cursor_new(cursor, filter_empty, filter_date, filter_chat, app
                             jid_new.raw_string as new_jid,
                             jid_global.type as jid_type,
                             COALESCE(receipt_user.receipt_timestamp, message.received_timestamp) as received_timestamp,
-                            COALESCE(receipt_user.read_timestamp, receipt_user.played_timestamp) as read_timestamp,
-                            {append_fields}
+                            COALESCE(receipt_user.read_timestamp, receipt_user.played_timestamp) as read_timestamp
                     FROM message
                         LEFT JOIN message_quoted
                             ON message_quoted.message_row_id = message._id
@@ -304,7 +282,6 @@ def _get_messages_cursor_new(cursor, filter_empty, filter_date, filter_chat, app
                             ON jid_new._id = message_system_number_change.new_jid_row_id
                         LEFT JOIN receipt_user
                             ON receipt_user.message_row_id = message._id
-                        {append_joins}
                     WHERE key_remote_jid <> '-1'
                         {empty_filter}
                         {date_filter}


### PR DESCRIPTION
Hello, thanks for this amazing project. Using this to archive my chats without relying on Meta and Google.

My backup has an empty wa.db #63, and I've used the [Enriching Contact from vCard](https://github.com/KnugiHK/WhatsApp-Chat-Exporter/wiki/Android-Usage#enriching-contact-from-vcard) feature. This worked and I want to propose some fixes to open issues in combination with this feature:
- a4318ac fixes #167 by mapping vCard names to the sender in group chats
- 695e45f does the same for internal messages: calls, group add/remove, etc.
- fcdda74 and a11f0a1 are cosmetic changes to improve `--debug`
- ee7db80 is a workaround for randomized JIDs #144 I tried to explain it in the commit message

Next I want to take a look if the internal messages can be improved a bit