### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/KnugiHK/WhatsApp-Chat-Exporter/security/code-scanning/4](https://github.com/KnugiHK/WhatsApp-Chat-Exporter/security/code-scanning/4)

In general, the fix is to define an explicit `permissions:` block in the workflow so that the `GITHUB_TOKEN` is limited to the least privilege necessary. For a CI workflow that only checks out code and runs tests, `contents: read` is typically sufficient, because `actions/checkout` only requires read access to fetch the repository.

The best way to fix this specific workflow without changing existing functionality is to add a `permissions:` block at the **job level** for the `ci` job, immediately under `runs-on:` (or at the top level, under `name:`). This will ensure the `GITHUB_TOKEN` has read-only access to repository contents and no write permissions. There is no need for additional imports or dependencies, and no other lines need to change.

Concretely:
- Edit `.github/workflows/ci.yml`.
- In the `ci` job definition, insert:

```yaml
    permissions:
      contents: read
```

directly after `runs-on: ${{ matrix.os }}` (line 10 in the provided snippet). The rest of the workflow remains identical.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
