### PR TITLE
✨ Quality: Crash in timestamp formatting when timezone_offset is None

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Do an iPhone/iPad Backup with iTunes/Finder first.
 > [!NOTE]
 > If you are working on unencrypted iOS/iPadOS backup, skip this.
 
-If you want to work on an encrypted iOS/iPadOS Backup, you should install iphone_backup_decrypt from [KnugiHK/iphone_backup_decrypt](https://github.com/KnugiHK/iphone_backup_decrypt) before you run the extract_iphone_media.py.
+If you want to work on an encrypted iOS/iPadOS Backup, you should install `iphone_backup_decrypt` from [KnugiHK/iphone_backup_decrypt](https://github.com/KnugiHK/iphone_backup_decrypt) before you run the extract_iphone_media.py.
 ```sh
 pip install git+https://github.com/KnugiHK/iphone_backup_decrypt
 ```

--- a/Whatsapp_Chat_Exporter/data_model.py
+++ b/Whatsapp_Chat_Exporter/data_model.py
@@ -30,7 +30,8 @@ class Timing:
         """
         if timestamp is not None:
             timestamp = timestamp / 1000 if timestamp > 9999999999 else timestamp
-            return datetime.fromtimestamp(timestamp, TimeZone(self.timezone_offset)).strftime(format)
+            tz = TimeZone(self.timezone_offset) if self.timezone_offset is not None else None
+            return datetime.fromtimestamp(timestamp, tz).strftime(format)
         return None
 
 

--- a/Whatsapp_Chat_Exporter/data_model.py
+++ b/Whatsapp_Chat_Exporter/data_model.py
@@ -15,7 +15,7 @@ class Timing:
         Args:
             timezone_offset (Optional[Union[int, float]]): Hours offset from UTC. Defaults to None (auto-detect).
         """
-        self.timezone_offset = timezone_offset
+        self.tz = TimeZone(timezone_offset) if timezone_offset is not None else None
 
     def format_timestamp(self, timestamp: Optional[Union[int, float]], format: str) -> Optional[str]:
         """
@@ -30,8 +30,7 @@ class Timing:
         """
         if timestamp is not None:
             timestamp = timestamp / 1000 if timestamp > 9999999999 else timestamp
-            tz = TimeZone(self.timezone_offset) if self.timezone_offset is not None else None
-            return datetime.fromtimestamp(timestamp, tz).strftime(format)
+            return datetime.fromtimestamp(timestamp, self.tz).strftime(format)
         return None
 
 

--- a/Whatsapp_Chat_Exporter/data_model.py
+++ b/Whatsapp_Chat_Exporter/data_model.py
@@ -8,12 +8,12 @@ class Timing:
     Handles timestamp formatting with timezone support.
     """
 
-    def __init__(self, timezone_offset: Optional[int] = None) -> None:
+    def __init__(self, timezone_offset: Optional[Union[int, float]] = None) -> None:
         """
         Initialize Timing object.
 
         Args:
-            timezone_offset (Optional[int]): Hours offset from UTC. Defaults to None (auto-detect).
+            timezone_offset (Optional[Union[int, float]]): Hours offset from UTC. Defaults to None (auto-detect).
         """
         self.timezone_offset = timezone_offset
 
@@ -40,12 +40,12 @@ class TimeZone(tzinfo):
     Custom timezone class with fixed offset.
     """
 
-    def __init__(self, offset: int) -> None:
+    def __init__(self, offset: Union[int, float]) -> None:
         """
         Initialize TimeZone object.
 
         Args:
-            offset (int): Hours offset from UTC
+            offset (Union[int, float]): Hours offset from UTC
         """
         self.offset = offset
 

--- a/Whatsapp_Chat_Exporter/data_model.py
+++ b/Whatsapp_Chat_Exporter/data_model.py
@@ -8,12 +8,12 @@ class Timing:
     Handles timestamp formatting with timezone support.
     """
 
-    def __init__(self, timezone_offset: Optional[int]) -> None:
+    def __init__(self, timezone_offset: Optional[int] = None) -> None:
         """
         Initialize Timing object.
 
         Args:
-            timezone_offset (Optional[int]): Hours offset from UTC
+            timezone_offset (Optional[int]): Hours offset from UTC. Defaults to None (auto-detect).
         """
         self.timezone_offset = timezone_offset
 

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -1,0 +1,55 @@
+import pytest
+from Whatsapp_Chat_Exporter.data_model import TimeZone, Timing
+from datetime import timedelta
+
+
+class TestTimeZone:
+    def test_utcoffset(self):
+        tz = TimeZone(5.5)
+        assert tz.utcoffset(None) == timedelta(hours=5.5)
+
+    def test_dst(self):
+        tz = TimeZone(2)
+        assert tz.dst(None) == timedelta(0)
+
+
+class TestTiming:   
+    @pytest.mark.parametrize("offset, expected_hour", [
+        (8, "08:00"),      # Integer (e.g., Hong Kong Standard Time)
+        (-8, "16:00"),     # Negative Integer (e.g., PST)
+        (5.5, "05:30"),    # Positive Float (e.g., IST)
+        (-3.5, "20:30"),   # Negative Float (e.g., Newfoundland)
+    ])
+
+    def test_format_timestamp_various_offsets(self, offset, expected_hour):
+        """Verify that both int and float offsets calculate time correctly."""
+        t = Timing(offset)
+        result = t.format_timestamp(1672531200, "%H:%M")
+        assert result == expected_hour
+
+    @pytest.mark.parametrize("ts_input", [
+        1672531200,        # Unix timestamp as int
+        1672531200.0,      # Unix timestamp as float
+    ])
+
+    def test_timestamp_input_types(self, ts_input):
+        """Verify the method accepts both int and float timestamps."""
+        t = Timing(0)
+        result = t.format_timestamp(ts_input, "%Y")
+        assert result == "2023"
+
+    def test_timing_none_offset(self):
+        """Verify initialization with None doesn't crash and uses system time."""
+        t = Timing(None)
+        assert t.tz is None
+        # Should still return a valid string based on local machine time without crashing
+        result = t.format_timestamp(1672531200, "%Y")
+        assert result == "2023"
+
+    def test_millisecond_scaling(self):
+        """Verify that timestamps in milliseconds are correctly scaled down."""
+        t = Timing(0)
+        # Milliseconds as int
+        assert t.format_timestamp(1672531200000, "%Y") == "2023"
+        # Milliseconds as float
+        assert t.format_timestamp(1672531200000.0, "%Y") == "2023"


### PR DESCRIPTION
## ✨ Code Quality

### Problem
In `Timing.format_timestamp`, if `self.timezone_offset` is `None` (which is explicitly allowed by the `Optional[int]` type hint), it instantiates `TimeZone(None)`. 
When `datetime.fromtimestamp()` calls the `utcoffset()` method on this timezone object, it executes `timedelta(hours=self.offset)`, which evaluates to `timedelta(hours=None)`. This raises a `TypeError: unsupported type for timedelta hours component: NoneType`, causing the application to crash during export.


**Severity**: `high`
**File**: `Whatsapp_Chat_Exporter/data_model.py`

### Solution
Update `format_timestamp` to only use the custom `TimeZone` if the offset is provided, otherwise fallback to a naive datetime or UTC:


### Changes
- `Whatsapp_Chat_Exporter/data_model.py` (modified)

# Important Note

**All PRs (except for changes unrelated to source files) should target and start from the `dev` branch.**

## Related Issue

- Please put a reference to the related issue here (e.g., `Fixes #123` or `Closes #456`), if there are any.

## Description of Changes

- Briefly describe the changes made in this PR. Explain the purpose, the implementation details, and any important information that reviewers should be aware of.

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #205