### PR TITLE
fix: handle None timezone_offset in timestamp formatting

### DIFF
--- a/Whatsapp_Chat_Exporter/data_model.py
+++ b/Whatsapp_Chat_Exporter/data_model.py
@@ -30,7 +30,11 @@ class Timing:
         """
         if timestamp is not None:
             timestamp = timestamp / 1000 if timestamp > 9999999999 else timestamp
-            return datetime.fromtimestamp(timestamp, TimeZone(self.timezone_offset)).strftime(format)
+            if self.timezone_offset is None:
+                return datetime.fromtimestamp(timestamp).strftime(format)
+            return datetime.fromtimestamp(
+                timestamp, TimeZone(self.timezone_offset)
+            ).strftime(format)
         return None
 
 

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,7 @@
+from Whatsapp_Chat_Exporter.data_model import Timing
+
+
+def test_format_timestamp_with_none_timezone_offset_does_not_crash():
+    timing = Timing(None)
+
+    assert timing.format_timestamp(1_700_000_000, "%Y") == "2023"


### PR DESCRIPTION
Fixes #205

`Timing.format_timestamp()` accepted `Optional[int]` for `timezone_offset`, but it always instantiated `TimeZone(self.timezone_offset)`. When the offset was `None`, this crashed in `timedelta(hours=None)`.

This keeps the existing timezone path for integer offsets and uses plain `datetime.fromtimestamp()` when offset is `None`. Added a regression test for the `None` case.

Greetings, saschabuehrle
