### PR TITLE
crypt14 decryption returns None on non-matching known offset

### DIFF
--- a/Whatsapp_Chat_Exporter/android_crypt.py
+++ b/Whatsapp_Chat_Exporter/android_crypt.py
@@ -170,6 +170,10 @@ def _decrypt_crypt14(database: bytes, main_key: bytes, max_worker: int = 10) -> 
         except (zlib.error, ValueError):
             continue
         else:
+            if decrypted_db is None:
+                # This known offset did not work (_attempt_decrypt_task returns
+                # None on failure); try the next offset instead of returning None.
+                continue
             logging.debug(
                 f"Decryption successful with known offsets: IV {iv}, DB {db}"
             )


### PR DESCRIPTION
Decrypting an Android `msgstore.db.crypt14` backup can fail even when the key file is correct. The user either sees a misleading crash:

```
TypeError: a bytes-like object is required, not 'NoneType'
```

(raised in `decrypt_backup` at `f.write(db)`), or decryption silently yields `None`. This makes people believe their `key` file is wrong, but it isn't:`_attempt_decrypt_task` catches `zlib.error` / `ValueError` and returns **`None`** on failure instead of raising:

```python
def _attempt_decrypt_task(offset_tuple, database, main_key):
    ...
    try:
        return _decrypt_database(db_ciphertext, main_key, iv)
    except (zlib.error, ValueError):
        return None
```

But the known-offsets loop in `_decrypt_crypt14` thinks "no exception raised" means "success", using `try/except/else`:

```python
for offsets in CRYPT14_OFFSETS:
    iv = offsets["iv"]
    db = offsets["db"]
    try:
        decrypted_db = _attempt_decrypt_task((iv, iv + 16, db), database, main_key)
    except (zlib.error, ValueError):
        continue
    else:
        logging.debug(...)
        return decrypted_db      # returns None on the FIRST offset that doesn't match
```

Since `_attempt_decrypt_task` never raises, the `except` branch is dead code and the `else` runs on the **very first** offset. If `CRYPT14_OFFSETS[0]` is not the right offset for that backup, `decrypted_db` is `None` and the function returns `None` immediately never trying the remaining known offsets or the bruteforce fallback.

Any crypt14 backup whose IV/DB offset isn't the first entry of `CRYPT14_OFFSETS` fails, despite being a valid key. (The key-signature check earlier in `decrypt_backup` passes, so the key is really correct.)

To fix this, we'll treat a `None` result as "this offset didn't work, try the next one":

```python
    else:
        if decrypted_db is None:
            continue      # this offset did not work; try the next known offset
        logging.debug(...)
        return decrypted_db
```

This lets the loop try all known offsets and, if none match, fall through to the existing brute-force path (which already handles `None` correctly via `if result:`).
