### PR TITLE
Fix nested iOS media directory extraction

### DIFF
--- a/Whatsapp_Chat_Exporter/ios_media_handler.py
+++ b/Whatsapp_Chat_Exporter/ios_media_handler.py
@@ -230,10 +230,7 @@ class BackupExtractor:
                     flags = row["flags"]
 
                     if flags == 2:  # Directory
-                        try:
-                            os.mkdir(destination)
-                        except FileExistsError:
-                            pass
+                        os.makedirs(destination, exist_ok=True)
                     elif flags == 1:  # File
                         shutil.copyfile(os.path.join(self.base_dir, folder, hashes), destination)
                         metadata = BPListReader(row["metadata"]).parse()

--- a/tests/test_ios_media_handler.py
+++ b/tests/test_ios_media_handler.py
@@ -1,0 +1,27 @@
+import sqlite3
+from types import SimpleNamespace
+
+from Whatsapp_Chat_Exporter.ios_media_handler import BackupExtractor
+
+
+def test_extract_media_files_creates_nested_directories(tmp_path, monkeypatch):
+    backup_dir = tmp_path / "backup"
+    backup_dir.mkdir()
+    with sqlite3.connect(backup_dir / "Manifest.db") as manifest:
+        manifest.execute(
+            "CREATE TABLE Files "
+            "(fileID TEXT, domain TEXT, relativePath TEXT, "
+            "flags INTEGER, file BLOB)"
+        )
+        manifest.execute(
+            "INSERT INTO Files VALUES (?, ?, ?, ?, ?)",
+            ("unused", "WhatsApp.shared", "parent/child", 2, None),
+        )
+
+    monkeypatch.chdir(tmp_path)
+    identifiers = SimpleNamespace(DOMAIN="WhatsApp.shared")
+
+    extractor = BackupExtractor(backup_dir, identifiers, decrypt_chunk_size=0)
+    extractor._extract_media_files()
+
+    assert (tmp_path / "WhatsApp.shared" / "parent" / "child").is_dir()


### PR DESCRIPTION
# Important Note

This source change targets and starts from the `dev` branch.

## Related Issue

Closes #228

## Description of Changes

Use `os.makedirs(..., exist_ok=True)` when extracting directory entries so nested iOS backup paths create their missing parents instead of raising `FileNotFoundError`. The regression test builds a minimal manifest containing a nested directory entry and verifies the full path is extracted.
