### PR TITLE
Feature/split output HTML file by month/quarter/year/size

### DIFF
--- a/SPLIT_FEATURE.md
+++ b/SPLIT_FEATURE.md
@@ -1,0 +1,174 @@
+# `--split` Feature: Output Splitting
+
+## Overview
+
+The `--split` flag controls how chat exports are split across multiple HTML
+files. It supports **time-based** splitting (monthly, quarterly, yearly) and
+**size-based** splitting.
+
+It replaces the old `--size` / `--output-size` flag, which is now **deprecated**
+but still works. When both are given, `--split` takes precedence.
+
+---
+
+## Usage
+
+```
+--split [m|q|y|#K|#M|0]
+```
+
+| Value | Mode | Behaviour |
+|-------|------|-----------|
+| `m`   | time | Split by **calendar month** → each file contains one month |
+| `q`   | time | Split by **calendar quarter** → each file contains Q1–Q4 |
+| `y`   | time | Split by **calendar year** |
+| `100K`| size | Split at ~100 KB per file |
+| `2M`  | size | Split at ~2 MB per file |
+| `10MB`| size | Split at ~10 MB per file (also accepts `KB`, `GB`) |
+| `0`   | size | Auto-size (defaults to ~5 MB internally, same as old `--size 0`) |
+| *(omitted)* | size | Same as `0` — bare `--split` with no argument defaults to auto-size |
+
+### Examples
+
+```bash
+# Monthly split
+wtsexporter -a --split m
+
+# Quarterly split
+wtsexporter -i --split q
+
+# Yearly split
+wtsexporter -a --split y
+
+# Size-based: 500 KB per file
+wtsexporter -i --split 500K
+
+# Size-based: 2 MB per file
+wtsexporter -a --split 2M
+
+# Auto-size (legacy behaviour)
+wtsexporter -a --split
+
+# Old flag still works (deprecated)
+wtsexporter -a --size 10MB
+```
+
+---
+
+## Output file naming
+
+### Time-based
+
+Messages are grouped chronologically by period. Each group produces one HTML
+file with a human-readable period suffix.
+
+| Mode   | Pattern                      | Example (chat `Mom`)            |
+|--------|------------------------------|----------------------------------|
+| Month  | `<chatname>-YYYY-MM.html`    | `Mom-2026-01.html`               |
+| Quarter| `<chatname>-YYYY-Q#.html`    | `Mom-2026-Q1.html`               |
+| Year   | `<chatname>-YYYY.html`       | `Mom-2026.html`                  |
+
+### Size-based
+
+When the accumulated estimated HTML size of messages exceeds the threshold,
+a new file is created. Files are numbered sequentially with zero-padded
+two-digit suffixes.
+
+| Pattern                         | Example                     |
+|---------------------------------|-----------------------------|
+| `<chatname>-part<NN>.html`      | `Mom-part01.html`           |
+
+> Note: the old `--size` flag previously used `chatname-1.html` / `chatname-2.html`
+> (no `part` prefix, no zero-padding). This has been changed to `-partNN` to avoid
+> ambiguity with month numbers (`chatname-01.html` could mean January or part 1).
+
+---
+
+## Navigation between pages
+
+All split files include **previous / next navigation links** in the HTML header.
+- The first page has no previous link.
+- The last page has no next link.
+- The links use relative paths (e.g. `href="./Mom-2026-02.html"`) so the
+  exported directory works when opened from a file browser or served via HTTP.
+
+---
+
+## Corner cases
+
+### Empty periods
+
+If a chat has messages only in Jan and Mar but not Feb, the `--split m` output
+produces only two files: `-2026-01.html` and `-2026-03.html`. **No empty file
+is created for February.** This is by design — only periods that actually
+contain messages generate output.
+
+### Single-period chats
+
+A chat spanning only one month (or one quarter/year) with `--split m` still
+produces a single file with the periodic suffix (e.g. `Mom-2026-01.html`)
+for consistency with multi-period outputs. The suffix is always included;
+it is never omitted for single-file edge cases.
+
+### Messages with timestamp 0
+
+If a message has `timestamp = 0` (Unix epoch), it is grouped under `1970-01`.
+These messages will appear in their own file if they are the only ones in that
+period, or alongside other January-1970 messages. This is a rare edge case
+that typically indicates a corrupt or placeholder message.
+
+### Backward compatibility with `--size`
+
+`--size` is deprecated but not removed. When `--size` is used, it is
+internally converted to the equivalent `("size", bytes)` tuple and processed
+by the same code path. The only behavioural difference is the file naming:
+`--size` now also produces `-partNN` files instead of bare numbers, so output
+is consistent regardless of which flag is used.
+
+### Interaction with `--date` filter
+
+When `--date` is combined with `--split`, the date filter is applied first
+during data extraction. Only messages within the filtered range are passed to
+the split logic. This means `--split m` on a chat filtered to a single week
+will produce exactly one file — the filter already reduced the
+message set.
+
+### Interaction with `--incremental-merge`
+
+`--split` operates on the HTML generation stage, which runs after incremental
+merge completes. The merge itself works on raw JSON data and is unaffected by
+the split mode.
+
+---
+
+## Implementation details (for PR)
+
+Two files were modified:
+
+### `__main__.py`
+
+- **New argument**: `--split` added to the `Output Options` group. Uses
+  `nargs='?'` with `const="0"` so it accepts an optional value.
+- **New helper** `parse_split_mode()`: converts the raw CLI value into a
+  canonical tuple `(mode, value)`. `mode` is either `"time"` (for m/q/y)
+  or `"size"` (for byte values). The function normalizes shorthand units —
+  `100K` → `100KB`, `2M` → `2MB` — before delegating to the existing
+  `readable_to_bytes()`.
+- **Validation**: `--split` and `--size` are reconciled at validation time.
+  If `--split` is given, it is parsed and stored in `args.split`. Otherwise
+  `--size` is converted to `("size", bytes)` and stored in `args.split` as
+  well. This means all downstream code reads a single attribute.
+- **Three call sites** updated to pass `args.split` instead of `args.size`.
+
+### `android_handler.py`
+
+- **`create_html()` parameter**: renamed from `maximum_size` to `split_mode`.
+  When `split_mode` is not `None`, it is unpacked as `(mode, value)` and
+  dispatched to `_split_by_time()` or `_generate_paginated_chat()`.
+- **`_generate_paginated_chat()`**: now generates `-partNN` filenames
+  (e.g. `chat-part01.html`) instead of the old `-N` / bare-first-page scheme.
+  The special case for `current_page == 1` that omitted the suffix was
+  removed — every page consistently uses `-part{page:02d}`.
+- **New function `_split_by_time()`**: iterates messages in order, groups
+  them by calendar period (month/quarter/year), and renders one HTML file
+  per group with correct prev/next navigation.

--- a/Whatsapp_Chat_Exporter/__main__.py
+++ b/Whatsapp_Chat_Exporter/__main__.py
@@ -128,8 +128,12 @@ def setup_argument_parser() -> ArgumentParser:
         help="Do not output html files"
     )
     output_group.add_argument(
-        "--size", "--output-size", "--split", dest="size", nargs='?', const="0", default=None,
-        help="Maximum (rough) size of a single output file in bytes, 0 for auto"
+        "--size", "--output-size", dest="size", nargs='?', const="0", default=None,
+        help="[deprecated: use --split] Maximum (rough) size of a single output file in bytes, 0 for auto"
+    )
+    output_group.add_argument(
+        "--split", dest="split", nargs='?', const="0", default=None,
+        help="Split output: m=monthly, q=quarterly, y=yearly, or size like 100K, 2M, 0=auto. Overrides --size."
     )
     output_group.add_argument(
         "--no-reply", dest="no_reply_ios", default=False, action='store_true',
@@ -353,14 +357,40 @@ def validate_args(parser: ArgumentParser, args) -> None:
         parser.error(
             "When --enrich-from-vcards is provided, you must also set --default-country-code")
 
-    # Size validation and conversion
-    if args.size is not None:
+    # Split flag validation (--split overrides deprecated --size)
+    def parse_split_mode(value: str) -> tuple:
+        if value in ('m', 'q', 'y'):
+            return ('time', value)
+        if value == '0':
+            return ('size', 0)
+        # Accept K/M shorthands (e.g. 100K, 2M) that readable_to_bytes doesn't handle
+        normalized = value
+        if value.upper().endswith('K') and not value.upper().endswith('KB'):
+            normalized = value + 'B'
+        elif value.upper().endswith('M') and not value.upper().endswith('MB'):
+            normalized = value + 'B'
         try:
-            args.size = readable_to_bytes(args.size)
+            return ('size', readable_to_bytes(normalized))
+        except ValueError:
+            raise ValueError(
+                "Invalid value for --split. Use m/q/y for time-based, "
+                "or a size like 100K, 2M, 0 for auto."
+            )
+
+    if args.split is not None:
+        try:
+            args.split = parse_split_mode(args.split)
+        except ValueError as e:
+            parser.error(str(e))
+    elif args.size is not None:
+        try:
+            args.split = ("size", readable_to_bytes(args.size))
         except ValueError:
             parser.error(
-                "The value for --split must be pure bytes or use a proper unit (e.g., 1048576 or 1MB)"
+                "The value for --size must be pure bytes or use a proper unit (e.g., 1048576 or 1MB)"
             )
+    else:
+        args.split = None
 
     # Date filter validation and processing
     if args.filter_date is not None:
@@ -655,7 +685,7 @@ def create_output_files(args, data: ChatCollection) -> None:
             args.template,
             args.embedded,
             args.offline,
-            args.size,
+            args.split,
             args.no_avatar,
             args.telegram_theme,
             args.headline
@@ -743,7 +773,7 @@ def process_exported_chat(args, data: ChatCollection) -> None:
             args.template,
             args.embedded,
             args.offline,
-            args.size,
+            args.split,
             args.no_avatar,
             args.telegram_theme,
             args.headline
@@ -835,7 +865,7 @@ def main():
             args.template,
             args.embedded,
             args.offline,
-            args.size,
+            args.split,
             args.no_avatar,
             args.telegram_theme,
             args.headline

--- a/Whatsapp_Chat_Exporter/android_handler.py
+++ b/Whatsapp_Chat_Exporter/android_handler.py
@@ -1169,7 +1169,7 @@ def create_html(
     template=None,
     embedded=False,
     offline_static=False,
-    maximum_size=None,
+    split_mode=None,
     no_avatar=False,
     experimental=False,
     headline=None
@@ -1194,18 +1194,32 @@ def create_html(
 
             safe_file_name, name = get_file_name(contact, current_chat)
 
-            if maximum_size is not None:
-                _generate_paginated_chat(
-                    current_chat,
-                    safe_file_name,
-                    name,
-                    contact,
-                    output_folder,
-                    template,
-                    w3css,
-                    maximum_size,
-                    headline
-                )
+            if split_mode is not None:
+                mode, value = split_mode
+                if mode == 'time':
+                    _split_by_time(
+                        current_chat,
+                        safe_file_name,
+                        name,
+                        contact,
+                        output_folder,
+                        template,
+                        w3css,
+                        value,
+                        headline
+                    )
+                elif mode == 'size':
+                    _generate_paginated_chat(
+                        current_chat,
+                        safe_file_name,
+                        name,
+                        contact,
+                        output_folder,
+                        template,
+                        w3css,
+                        value,
+                        headline
+                    )
             else:
                 _generate_single_chat(
                     current_chat,
@@ -1259,7 +1273,7 @@ def _generate_paginated_chat(current_chat, safe_file_name, name, contact, output
 
         if current_size > maximum_size:
             # Create a new page
-            output_file_name = f"{output_folder}/{safe_file_name}-{current_page}.html"
+            output_file_name = f"{output_folder}/{safe_file_name}-part{current_page:02d}.html"
             rendering(
                 output_file_name,
                 template,
@@ -1269,8 +1283,8 @@ def _generate_paginated_chat(current_chat, safe_file_name, name, contact, output
                 w3css,
                 current_chat,
                 headline,
-                next=f"{safe_file_name}-{current_page + 1}.html",
-                previous=f"{safe_file_name}-{current_page - 1}.html" if current_page > 1 else False
+                next=f"{safe_file_name}-part{current_page + 1:02d}.html",
+                previous=f"{safe_file_name}-part{current_page - 1:02d}.html" if current_page > 1 else False
             )
             render_box = [message]
             current_size = 0
@@ -1279,10 +1293,7 @@ def _generate_paginated_chat(current_chat, safe_file_name, name, contact, output
             render_box.append(message)
             if message.key_id == last_msg:
                 # Last message, create final page
-                if current_page == 1:
-                    output_file_name = f"{output_folder}/{safe_file_name}.html"
-                else:
-                    output_file_name = f"{output_folder}/{safe_file_name}-{current_page}.html"
+                output_file_name = f"{output_folder}/{safe_file_name}-part{current_page:02d}.html"
                 rendering(
                     output_file_name,
                     template,
@@ -1293,8 +1304,53 @@ def _generate_paginated_chat(current_chat, safe_file_name, name, contact, output
                     current_chat,
                     headline,
                     False,
-                    previous=f"{safe_file_name}-{current_page - 1}.html"
+                    previous=f"{safe_file_name}-part{current_page - 1:02d}.html" if current_page > 1 else False
                 )
+
+
+def _split_by_time(current_chat, safe_file_name, name, contact, output_folder, template, w3css, period, headline):
+    """Split chat by time period: m=monthly, q=quarterly, y=yearly."""
+    pages = []
+    current_period = None
+    current_messages = []
+
+    for message in current_chat.values():
+        dt = datetime.fromtimestamp(message.timestamp)
+        if period == 'm':
+            key = dt.strftime('%Y-%m')
+        elif period == 'q':
+            quarter = (dt.month - 1) // 3 + 1
+            key = f'{dt.year}-Q{quarter}'
+        elif period == 'y':
+            key = dt.strftime('%Y')
+
+        if key != current_period:
+            if current_messages:
+                pages.append((current_period, current_messages))
+            current_period = key
+            current_messages = [message]
+        else:
+            current_messages.append(message)
+
+    if current_messages:
+        pages.append((current_period, current_messages))
+
+    for i, (period_key, msgs) in enumerate(pages):
+        output_file_name = f"{output_folder}/{safe_file_name}-{period_key}.html"
+        prev_file = f"{safe_file_name}-{pages[i-1][0]}.html" if i > 0 else False
+        next_file = f"{safe_file_name}-{pages[i+1][0]}.html" if i < len(pages) - 1 else False
+        rendering(
+            output_file_name,
+            template,
+            name,
+            msgs,
+            contact,
+            w3css,
+            current_chat,
+            headline,
+            next=next_file,
+            previous=prev_file
+        )
 
 
 def create_txt(data, output):


### PR DESCRIPTION
# Important Note

**All PRs (except for changes unrelated to source files) should target and start from the `dev` branch.**

## Related Issue

- Please put a reference to the related issue here (e.g., `Fixes #123` or `Closes #456`), if there are any.
See https://github.com/KnugiHK/WhatsApp-Chat-Exporter/issues/136

## Description of Changes

## Summary

Adds a `--split` flag that replaces the deprecated `--size` / `--output-size` flag. Supports both time-based splitting (monthly, quarterly, yearly) and size-based splitting with shorthand units (e.g. `100K`, `2M`).

--split co-exists with --size and takes precedence, until --size is fully deprecated and removed. 

This is only tested on iPhone. Even though the changed file is android_handler.py, iOS is covered. 

This also fixes a bug that when the chats are big enough, we have MemoryError during the "Generating HTML" stage. 

## Changes

### `__main__.py`
- Added `--split` argument (long-form only; `-s` conflicts with existing `--showkey`)
- Added `parse_split_mode()` to handle time codes (`m`/`q`/`y`), size values (`100K`, `2M`, `0`), and normalizes `K`/`M` shorthands for the existing `readable_to_bytes`
- `--size` is deprecated but kept for backward compatibility; `--split` overrides it when both are provided
- Both flags converge to the same `(mode, value)` tuple stored in `args.split`

### `android_handler.py`
- `create_html()` parameter renamed from `maximum_size` to `split_mode` — dispatches to `_split_by_time()` or `_generate_paginated_chat()` based on mode
- New `_split_by_time()`: groups messages by month/quarter/year using `datetime.fromtimestamp(message.timestamp)`, renders one HTML per period with prev/next navigation
- `_generate_paginated_chat()` updated to use `-partNN` filenames (e.g. `chat-part01.html`) instead of bare numbers, removing the ambiguous special-case for first-page naming

## File naming

| Mode | Pattern | Example |
|------|---------|---------|
| Monthly | `chatname-YYYY-MM.html` | `Mom-2026-01.html` |
| Quarterly | `chatname-YYYY-Q#.html` | `Mom-2026-Q1.html` |
| Yearly | `chatname-YYYY.html` | `Mom-2026.html` |
| Size | `chatname-partNN.html` | `Mom-part01.html` |

## Notes
- No changes to templates, iOS handler, data model, or utility files
- See `SPLIT_FEATURE.md` for full usage documentation and edge cases
- Closes #issue_number (if applicable)
