### PR TITLE
Feature/Add lightweight self-contained HTML template (whatsapp_simple.html) that works for both iOS Quick Look/File Peek and full browser

### DIFF
--- a/Whatsapp_Chat_Exporter/utility.py
+++ b/Whatsapp_Chat_Exporter/utility.py
@@ -832,7 +832,7 @@ def setup_template(template: Optional[str], no_avatar: bool, experimental: bool 
         template_dir = os.path.dirname(__file__)
         template_file = "whatsapp.html" if not experimental else template
     else:
-        template_dir = os.path.dirname(template)
+        template_dir = os.path.dirname(template) or os.path.dirname(__file__)
         template_file = os.path.basename(template)
     template_loader = jinja2.FileSystemLoader(searchpath=template_dir)
     template_env = jinja2.Environment(loader=template_loader, autoescape=True)

--- a/Whatsapp_Chat_Exporter/whatsapp_simple.html
+++ b/Whatsapp_Chat_Exporter/whatsapp_simple.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{ name }} - WhatsApp</title>
+<base href="{{ media_base }}" target="_blank">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: -apple-system, Helvetica, Arial, sans-serif; font-size: 15px; color: #111; background: #e5ddd5; padding: 10px 0; }
+a { color: #075e54; }
+#container { max-width: 700px; margin: 0 auto; padding: 0 10px; }
+.headline { text-align: center; padding: 12px; font-size: 17px; font-weight: bold; color: #075e54; border-bottom: 1px solid #ccc; margin-bottom: 10px; }
+.nav { text-align: center; padding: 10px 0; font-size: 14px; }
+.nav a { margin: 0 8px; text-decoration: none; }
+.date-sep { text-align: center; margin: 16px 0; font-size: 12px; color: #555; }
+.system-msg { text-align: center; margin: 12px 0; font-size: 13px; color: #555; font-style: italic; }
+.msg-row { display: flex; margin-bottom: 8px; }
+.msg-row.incoming { justify-content: flex-start; }
+.msg-row.outgoing { justify-content: flex-end; }
+.bubble { max-width: 85%; padding: 7px 9px; border-radius: 8px; position: relative; word-wrap: break-word; }
+.bubble.incoming { background: #fff; border: 1px solid #e0e0e0; }
+.bubble.outgoing { background: #dcf8c6; }
+.sender { font-size: 13px; font-weight: bold; color: #075e54; margin-bottom: 2px; }
+.text { font-size: 15px; line-height: 1.4; }
+.text img { max-width: 100%; height: auto; border-radius: 4px; }
+.media-img { max-width: 100%; height: auto; border-radius: 4px; display: block; margin-bottom: 4px; }
+.audio-link { display: inline-block; padding: 8px 12px; background: #075e54; color: #fff !important; text-decoration: none; border-radius: 4px; font-size: 14px; }
+.caption { font-size: 14px; margin-top: 2px; }
+.quote { border-left: 3px solid #075e54; padding: 4px 8px; margin-bottom: 4px; font-size: 13px; background: rgba(0,0,0,0.03); border-radius: 4px; color: #555; }
+.time { font-size: 11px; color: #888; text-align: right; margin-top: 2px; }
+.reactions { font-size: 14px; margin-top: 2px; letter-spacing: 1px; }
+.status { text-align: center; font-size: 12px; color: #888; padding: 5px 0; }
+.footer { text-align: center; padding: 20px 0; font-size: 12px; color: #888; }
+</style>
+</head>
+<body>
+<div id="container">
+<div class="headline">{{ headline }}</div>
+{% set ns = namespace(last_ts=0) %}
+{% if previous %}
+<div class="nav"><a href="./{{ previous }}">&larr; Previous</a></div>
+{% endif %}
+{% for msg in msgs %}
+{% set day_change = determine_day(ns.last_ts, msg.timestamp) %}
+{% if day_change %}
+<div class="date-sep">{{ day_change.strftime("%B %d, %Y") }}</div>
+{% endif %}
+{% set ns.last_ts = msg.timestamp %}
+{% if msg.meta %}
+<div class="system-msg">{{ msg.data | default('') }}</div>
+{% elif msg.media %}
+<div class="msg-row {{ 'outgoing' if msg.from_me else 'incoming' }}">
+<div class="bubble {{ 'outgoing' if msg.from_me else 'incoming' }}">
+{% if not msg.from_me and msg.sender %}<div class="sender">{{ (msg.sender or '') | sanitize_except }}</div>{% endif %}
+{% if msg.thumb and ("image/" in (msg.mime or "") or msg.thumb.startswith("/9j/") or msg.thumb.startswith("iVBOR")) %}
+{% if msg.data and not msg.data.startswith("data:") %}<a href="{{ msg.data }}">{% endif %}
+<img class="media-img" src="data:image/jpeg;base64,{{ msg.thumb }}" alt="" />
+{% if msg.data and not msg.data.startswith("data:") %}</a>{% endif %}
+{% elif msg.data and (msg.data.startswith("data:image") or msg.data.startswith("http")) %}
+<img class="media-img" src="{{ msg.data }}" alt="" />
+{% elif msg.data and "image/" in (msg.mime or "") %}
+<a href="{{ msg.data }}"><img class="media-img" src="{{ msg.data }}" alt="" /></a>
+{% elif msg.data and "video/" in (msg.mime or "") %}
+<video class="media-img" controls preload="metadata" src="{{ msg.data }}"></video>
+{% elif msg.data and "audio/" in (msg.mime or "") %}
+<audio controls="controls" preload="metadata">
+<source src="{{ msg.data }}"{% if msg.mime and "/" in msg.mime %} type="{{ msg.mime }}"{% endif %} />
+</audio>
+<a class="audio-link" href="{{ msg.data }}">Audio message</a>
+{% elif msg.data %}
+<a href="{{ msg.data }}">{{ msg.data }}</a>
+{% endif %}
+{% if msg.caption %}<div class="caption">{{ (msg.caption or '') | sanitize_except }}</div>{% endif %}
+<div class="time">{{ msg.time }}</div>
+{% if msg.reactions %}<div class="reactions">{% for emoji, reactors in msg.reactions.items() %}{{ emoji }}{% endfor %}</div>{% endif %}
+</div>
+</div>
+{% else %}
+{% set replied = msgs | selectattr('key_id', 'equalto', msg.reply) | first if msg.reply else none %}
+<div class="msg-row {{ 'outgoing' if msg.from_me else 'incoming' }}">
+<div class="bubble {{ 'outgoing' if msg.from_me else 'incoming' }}">
+{% if not msg.from_me and msg.sender %}<div class="sender">{{ (msg.sender or '') | sanitize_except }}</div>{% endif %}
+{% if replied %}
+<div class="quote">
+{% if replied.sender %}<strong>{{ (replied.sender or '') | sanitize_except }}</strong>: {% endif %}{{ (replied.data or '') | sanitize_except if replied.data else "[Media]" }}
+</div>
+{% endif %}
+<div class="text">{{ (msg.data or '') | sanitize_except }}</div>
+<div class="time">{{ msg.time }}</div>
+{% if msg.reactions %}<div class="reactions">{% for emoji, reactors in msg.reactions.items() %}{{ emoji }}{% endfor %}</div>{% endif %}
+</div>
+</div>
+{% endif %}
+{% endfor %}
+{% if next %}
+<div class="nav"><a href="./{{ next }}">Next &rarr;</a></div>
+{% endif %}
+<div class="footer">Exported with WhatsApp Chat Exporter</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
# Important Note

**All PRs (except for changes unrelated to source files) should target and start from the `dev` branch.**

## Related Issue

- Please put a reference to the related issue here (e.g., `Fixes #123` or `Closes #456`), if there are any.

## Description of Changes

Add lightweight self-contained HTML template (whatsapp_simple.html). This  new template is designed for iOS Quick Look / file peek and users who want a clean, fast export without external dependencies. It also works in the full browser. 

It does not replace the existing default HTML template. Only introduces a new one that a user can choose to use. 

Without this feature, the default template whatsapp.html will result in a HTML file that's not rendered properly (even with --offline switch) in iOS Quick Look/File Peek. The messages are all aligned to the left (than left and right), and bg color is not rendered so you can't tell which is from self and which is from others.  iOS File Peek does not load any external resources, and external CSS /tailwind will not work even if they are downloaded into offline static files. 

### Changes

Whatsapp_Chat_Exporter/whatsapp_simple.html — new self-contained template:

- All CSS inlined, no external font/CDN dependencies
- No Tailwind classes, no w3.css — pure inline styles
- <base href="{{ media_base }}"> for media path resolution
- Works in both full browser and iOS Quick Look file peek
- Media support: clickable thumbnails → full photo, <video> with controls, <audio> with <source type> + visible "Audio message" fallback link
- Backward compatible: --template whatsapp_simple.html selects it

Whatsapp_Chat_Exporter/utility.py:

- setup_template(): when --template is a bare filename (no directory), look in the package directory first before CWD. Makes --template whatsapp_simple.html work from anywhere.

Usage: 

`python -m Whatsapp_Chat_Exporter --template whatsapp_simple.html ...`

Tests performed:

1. opus audio, mp4, photos links all work in full browsers on windows. 
2. HTML output files in Iphone/IOS Quick Look/File Peek, look and feel similar to full browser except the media links are not clickable/usable. 
