### PR TITLE
fix: detect iOS quoted replies with any parent ID length

### DIFF
--- a/Whatsapp_Chat_Exporter/ios_handler.py
+++ b/Whatsapp_Chat_Exporter/ios_handler.py
@@ -287,10 +287,15 @@ def process_message_data(message, content, is_group_message, data, message_map, 
         return process_metadata_message(message, content, is_group_message, data)
 
     # Handle quoted replies
-    if content["ZMETADATA"] is not None and content["ZMETADATA"].startswith(b"\x2a\x14") and not no_reply:
-        quoted = content["ZMETADATA"][2:19]
-        message.reply = quoted.decode()
-        message.quoted_data = message_map.get(message.reply)
+    metadata = content["ZMETADATA"]
+    if metadata is not None and not no_reply and len(metadata) >= 2 and metadata[0] == 0x2A:
+        # The byte after the 0x2A tag is the length of the quoted message ID,
+        # which is not always 0x14, so read it instead of assuming it.
+        quoted_length = metadata[1]
+        quoted = metadata[2:2 + quoted_length]
+        if len(quoted) == quoted_length and quoted.isascii():
+            message.reply = quoted.decode("ascii")[:17]
+            message.quoted_data = message_map.get(message.reply)
 
     # Skip poll vote update messages (type 66)
     if content["ZMESSAGETYPE"] == 66:

--- a/Whatsapp_Chat_Exporter/ios_handler.py
+++ b/Whatsapp_Chat_Exporter/ios_handler.py
@@ -291,9 +291,9 @@ def process_message_data(message, content, is_group_message, data, message_map, 
     if metadata is not None and not no_reply and len(metadata) >= 2 and metadata[0] == 0x2A:
         # The byte after the 0x2A tag is the length of the quoted message ID,
         # which is not always 0x14, so read it instead of assuming it.
-        quoted_length = metadata[1]
-        quoted = metadata[2:2 + quoted_length]
-        if len(quoted) == quoted_length and quoted.isascii():
+        quoted_msg_id_length = metadata[1]
+        quoted = metadata[2:2 + quoted_msg_id_length]
+        if len(quoted) == quoted_msg_id_length and quoted.isascii():
             message.reply = quoted.decode("ascii")[:17]
             message.quoted_data = message_map.get(message.reply)
 

--- a/tests/test_ios_handler.py
+++ b/tests/test_ios_handler.py
@@ -1,0 +1,64 @@
+import pytest
+
+from Whatsapp_Chat_Exporter.data_model import Message
+from Whatsapp_Chat_Exporter.ios_handler import process_message_data
+
+
+def make_content(metadata):
+    return {
+        "ZISFROMME": 1,
+        "ZMESSAGETYPE": 0,
+        "ZMETADATA": metadata,
+        "ZTEXT": "hi",
+        "ZMESSAGETEXT": None,
+    }
+
+
+def make_message():
+    return Message(from_me=1, timestamp=0, time=0, key_id="k", message_type=0)
+
+
+def quoted_metadata(parent_id):
+    """Build a ZMETADATA blob: 0x2A tag, length byte, then the quoted ID."""
+    return b"\x2a" + bytes([len(parent_id)]) + parent_id.encode()
+
+
+@pytest.mark.parametrize("parent_id", ["A" * 20, "B" * 22, "C" * 16])
+def test_quoted_reply_detected_for_any_parent_id_length(parent_id):
+    message = make_message()
+    message_map = {parent_id[:17]: "parent text"}
+
+    process_message_data(
+        message, make_content(quoted_metadata(parent_id)), False, None, message_map, False
+    )
+
+    assert message.reply == parent_id[:17]
+    assert message.quoted_data == "parent text"
+
+
+def test_non_reply_metadata_starting_with_tag_byte_is_ignored():
+    message = make_message()
+
+    # Length byte claims 30 bytes but only 2 follow, so this is not a quoted reply.
+    process_message_data(
+        message, make_content(b"\x2a\x1e\xff\xfe"), False, None, {}, False
+    )
+
+    assert message.reply is None
+    assert message.quoted_data is None
+
+
+def test_no_reply_flag_skips_quoted_reply_parsing():
+    message = make_message()
+    parent_id = "D" * 20
+
+    process_message_data(
+        message,
+        make_content(quoted_metadata(parent_id)),
+        False,
+        None,
+        {parent_id[:17]: "parent text"},
+        True,
+    )
+
+    assert message.reply is None


### PR DESCRIPTION
# Pre-flight Check

- [ ] This PR does not modify any source files (e.g., only updates the README).
- [x] This PR modifies one or more source files and targets the `dev` branch.

## Related Issue

Fixes #218

## Description of Changes

The iOS quoted-reply parser matched `ZMETADATA` against the literal prefix `b"\x2a\x14"` and then sliced a fixed 17 characters. The `0x14` byte is the *length* of the quoted message ID, not a constant, so every reply whose parent ID is not 20 bytes was skipped and exported with `reply`/`quoted_data` as null.

The fix reads the length byte instead of assuming it, and validates that the declared number of ASCII bytes is actually present so unrelated metadata starting with the `0x2A` tag is still ignored. Output for the 20-byte IDs that already worked is unchanged.

`tests/test_ios_handler.py` covers 16/20/22-byte parent IDs, the malformed-metadata guard, and `--no-reply`. The two length-varying cases fail on `dev` and pass with the fix; the rest of the suite is unchanged (same 4 pre-existing failures before and after).
