### PR TITLE
Fix iOS media path resolution and warn on missing media

### DIFF
--- a/Whatsapp_Chat_Exporter/__main__.py
+++ b/Whatsapp_Chat_Exporter/__main__.py
@@ -17,7 +17,7 @@ from Whatsapp_Chat_Exporter.utility import readable_to_bytes, safe_name, bytes_t
 from Whatsapp_Chat_Exporter.utility import import_from_json, incremental_merge, check_update
 from Whatsapp_Chat_Exporter.utility import telegram_json_format, convert_time_unit, DbType
 from Whatsapp_Chat_Exporter.utility import get_transcription_selection, check_jid_map
-from Whatsapp_Chat_Exporter.utility import media_folder_name
+from Whatsapp_Chat_Exporter.utility import media_folder_name, validate_media_folder, Device
 from argparse import ArgumentParser, SUPPRESS
 from datetime import datetime
 from getpass import getpass
@@ -553,6 +553,14 @@ def process_contacts(args, data: ChatCollection) -> None:
     """Process contacts from the database."""
     contact_db = args.wa if args.wa else "wa.db" if args.android else "ContactsV2.sqlite"
 
+    if not os.path.isfile(contact_db):
+        logging.warning(
+            f"Contact database not found, contact names may be missing or incomplete: "
+            f"{os.path.abspath(contact_db)}"
+        )
+        if os.path.isdir(contact_db):
+            logging.warning("--wa takes the path to the database file itself, not a directory.")
+
     if os.path.isfile(contact_db):
         with sqlite3.connect(contact_db) as db:
             db.row_factory = sqlite3.Row
@@ -906,6 +914,14 @@ def main():
             )
             logging.info(f"Incremental merge completed successfully.")
         else:
+            # Check the media path before any work is done, so that a wrong path is
+            # reported in the first second rather than after the export has finished
+            validate_media_folder(
+                args.media,
+                Device.ANDROID if args.android else Device.IOS,
+                android_handler.MEDIA_PATH_HINT if args.android else ios_handler.MEDIA_PATH_HINT
+            )
+
             # Process contacts
             process_contacts(args, data)
 

--- a/Whatsapp_Chat_Exporter/__main__.py
+++ b/Whatsapp_Chat_Exporter/__main__.py
@@ -17,6 +17,7 @@ from Whatsapp_Chat_Exporter.utility import readable_to_bytes, safe_name, bytes_t
 from Whatsapp_Chat_Exporter.utility import import_from_json, incremental_merge, check_update
 from Whatsapp_Chat_Exporter.utility import telegram_json_format, convert_time_unit, DbType
 from Whatsapp_Chat_Exporter.utility import get_transcription_selection, check_jid_map
+from Whatsapp_Chat_Exporter.utility import media_folder_name
 from argparse import ArgumentParser, SUPPRESS
 from datetime import datetime
 from getpass import getpass
@@ -81,11 +82,16 @@ def setup_argument_parser() -> ArgumentParser:
     input_group = parser.add_argument_group('Input Files')
     input_group.add_argument(
         "-w", "--wa", dest="wa", default=None,
-        help="Path to contact database (default: wa.db/ContactsV2.sqlite)"
+        help="Path to the contact database file, not a directory "
+             "(default: wa.db/ContactsV2.sqlite)"
     )
     input_group.add_argument(
         "-m", "--media", dest="media", default=None,
-        help="Path to WhatsApp media folder (default: WhatsApp)"
+        help="Path to the folder that CONTAINS the WhatsApp media folder. For Android "
+             "this is the WhatsApp directory holding Media/ (default: WhatsApp); for "
+             "iOS/iPadOS this is the extracted app group directory holding Message/ and "
+             "Media/ (default: AppDomainGroup-group.net.whatsapp.WhatsApp.shared). Do "
+             "not point this at Message/Media itself"
     )
     input_group.add_argument(
         "-b", "--backup", dest="backup", default=None,
@@ -625,7 +631,9 @@ def process_calls(args, db, data: ChatCollection, filter_chat, timing) -> None:
 def handle_media_directory(args) -> None:
     """Handle media directory copying or moving."""
     if os.path.isdir(args.media):
-        media_path = os.path.join(args.output, args.media)
+        # The basename is used so that an absolute --media path lands inside the
+        # output directory instead of resolving back to the source directory.
+        media_path = os.path.join(args.output, media_folder_name(args.media))
 
         if os.path.isdir(media_path):
             logging.info(

--- a/Whatsapp_Chat_Exporter/android_handler.py
+++ b/Whatsapp_Chat_Exporter/android_handler.py
@@ -15,7 +15,14 @@ from Whatsapp_Chat_Exporter.utility import MAX_SIZE, ROW_SIZE, JidType, Device, 
 from Whatsapp_Chat_Exporter.utility import rendering, get_file_name, setup_template, get_cond_for_empty
 from Whatsapp_Chat_Exporter.utility import get_status_location, convert_time_unit, get_jid_map_selection
 from Whatsapp_Chat_Exporter.utility import get_chat_condition, safe_name, bytes_to_readable, determine_metadata
+from Whatsapp_Chat_Exporter.utility import log_missing_media
 from Whatsapp_Chat_Exporter.media_timestamp import process_media_with_timestamp
+
+
+MEDIA_PATH_HINT = (
+    "For Android, --media must point at the WhatsApp directory that contains the "
+    "\"Media\" folder (usually named \"WhatsApp\")."
+)
 
 
 
@@ -611,13 +618,18 @@ def media(db, data, media_folder, filter_date, filter_chat, filter_empty, separa
     # Ensure thumbnails directory exists
     Path(f"{media_folder}/thumbnails").mkdir(parents=True, exist_ok=True)
 
+    missing = 0
+    looked_up = 0
     with tqdm(total=total_row_number, desc="Processing media", unit="media", leave=False) as pbar:
         while (content := _fetch_row_safely(content_cursor)) is not None:
-            _process_single_media(data, content, media_folder, mime, separate_media, fix_dot_files,
-                              embed_exif, rename_media, timezone_offset)
+            looked_up += 1
+            if not _process_single_media(data, content, media_folder, mime, separate_media,
+                                         fix_dot_files, embed_exif, rename_media, timezone_offset):
+                missing += 1
             pbar.update(1)
         total_time = pbar.format_dict['elapsed']
     logging.info(f"Processed {total_row_number} media in {convert_time_unit(total_time)}")
+    log_missing_media(missing, looked_up, media_folder, MEDIA_PATH_HINT)
 
 
 # Helper functions for media processing
@@ -765,7 +777,12 @@ def _get_media_cursor_new(cursor, filter_empty, filter_date, filter_chat):
 
 def _process_single_media(data, content, media_folder, mime, separate_media, fix_dot_files=False, 
                           embed_exif=False, rename_media=False, timezone_offset=0):
-    """Process a single media file."""
+    """
+    Process a single media file.
+
+    Returns:
+        bool: True if the media file was found on disk, False otherwise.
+    """
     file_path = f"{media_folder}/{content['file_path']}"
     current_chat = data.get_chat(content["key_remote_jid"])
     message = current_chat.get_message(content["message_row_id"])
@@ -819,10 +836,12 @@ def _process_single_media(data, content, media_folder, mime, separate_media, fix
         else:
             final_path = file_path
         message.data = final_path
+        found = True
     else:
         message.data = "The media is missing"
         message.mime = "media"
         message.meta = True
+        found = False
 
     # Handle thumbnail
     if content["thumbnail"] is not None:
@@ -831,6 +850,8 @@ def _process_single_media(data, content, media_folder, mime, separate_media, fix
             with open(thumb_path, "wb") as f:
                 f.write(content["thumbnail"])
         message.thumb = thumb_path
+
+    return found
 
 
 def vcard(db, data, media_folder, filter_date, filter_chat, filter_empty):

--- a/Whatsapp_Chat_Exporter/data_model.py
+++ b/Whatsapp_Chat_Exporter/data_model.py
@@ -1,4 +1,3 @@
-import os
 from datetime import datetime, tzinfo, timedelta
 from typing import MutableMapping, Union, Optional, Dict, Any
 
@@ -234,20 +233,20 @@ class ChatStore:
         self.name = name
         self._messages: Dict[str, 'Message'] = {}
         self.type = type
+        self.my_avatar = None
+        self.media_base = ""
         if media is not None:
-            from Whatsapp_Chat_Exporter.utility import Device
+            from Whatsapp_Chat_Exporter.utility import Device, media_base_href
             if self.type == Device.IOS:
-                self.my_avatar = os.path.join(media, "Media/Profile/Photo.jpg")
+                # Output paths are resolved against media_base, so they are stored
+                # relative to the media folder rather than as filesystem paths.
+                self.my_avatar = "Media/Profile/Photo.jpg"
+                self.media_base = media_base_href(media)
             elif self.type == Device.ANDROID:
                 self.my_avatar = None  # TODO: Add Android support
-            else:
-                self.my_avatar = None
-        else:
-            self.my_avatar = None
         self.their_avatar = None
         self.their_avatar_thumb = None
         self.status = None
-        self.media_base = ""
         self.aliases = []
 
     def __len__(self) -> int:

--- a/Whatsapp_Chat_Exporter/ios_handler.py
+++ b/Whatsapp_Chat_Exporter/ios_handler.py
@@ -410,7 +410,8 @@ def media(db, data, media_folder, filter_date, filter_chat, filter_empty, separa
         filter_chat[1], False, ["ZWACHATSESSION.ZCONTACTJID", "ZMEMBERJID"], "ZGROUPINFO", "ios")
     date_filter = f'AND ZMESSAGEDATE {filter_date}' if filter_date is not None else ''
 
-    # Get media count
+    # Get media count. This must use the same conditions as the query below,
+    # otherwise the reported total counts rows that are never processed.
     media_count_query = f"""
         SELECT count()
         FROM ZWAMEDIAITEM
@@ -420,7 +421,7 @@ def media(db, data, media_folder, filter_date, filter_chat, filter_empty, separa
                 ON ZWAMESSAGE.ZCHATSESSION = ZWACHATSESSION.Z_PK
             LEFT JOIN ZWAGROUPMEMBER
                 ON ZWAMESSAGE.ZGROUPMEMBER = ZWAGROUPMEMBER.Z_PK
-        WHERE 1=1
+        WHERE ZMEDIALOCALPATH IS NOT NULL
             {date_filter}
             {chat_filter_include}
             {chat_filter_exclude}

--- a/Whatsapp_Chat_Exporter/ios_handler.py
+++ b/Whatsapp_Chat_Exporter/ios_handler.py
@@ -12,8 +12,19 @@ from markupsafe import escape as htmle
 from Whatsapp_Chat_Exporter.data_model import ChatStore, Message
 from Whatsapp_Chat_Exporter.utility import APPLE_TIME, get_chat_condition, Device
 from Whatsapp_Chat_Exporter.utility import bytes_to_readable, convert_time_unit, safe_name
+from Whatsapp_Chat_Exporter.utility import log_missing_media, media_base_href, to_media_relative_path
 from Whatsapp_Chat_Exporter.poll import decode_poll_from_receipt_blob
 from Whatsapp_Chat_Exporter.media_timestamp import process_media_with_timestamp
+
+
+MEDIA_PATH_HINT = (
+    "For iOS/iPadOS, --media must point at the extracted app group directory that "
+    "contains the \"Message\" and \"Media\" folders (usually named "
+    "\"AppDomainGroup-group.net.whatsapp.WhatsApp.shared\"), not at the media "
+    "folder inside it. The \"Message/\" prefix is added by this tool."
+)
+
+
 
 
 def contacts(db, data):
@@ -63,13 +74,13 @@ def process_contact_avatars(current_chat, media_folder, contact_id):
     avatars = glob(f"{path}*")
 
     if 0 < len(avatars) <= 1:
-        current_chat.their_avatar = avatars[0]
+        current_chat.their_avatar = to_media_relative_path(avatars[0], media_folder)
     else:
         for avatar in avatars:
             if avatar.endswith(".thumb") and current_chat.their_avatar_thumb is None:
-                current_chat.their_avatar_thumb = avatar
+                current_chat.their_avatar_thumb = to_media_relative_path(avatar, media_folder)
             elif avatar.endswith(".jpg") and current_chat.their_avatar is None:
-                current_chat.their_avatar = avatar
+                current_chat.their_avatar = to_media_relative_path(avatar, media_folder)
 
 
 def get_contact_name(content):
@@ -150,7 +161,8 @@ def messages(db, data, media_folder, timezone_offset, filter_date, filter_chat, 
                     is_phone = contact_name.replace("+", "").replace(" ", "").isdigit() if contact_name else True
                     if not is_phone or current_chat.name is None:
                         current_chat.name = contact_name
-                current_chat.my_avatar = os.path.join(media_folder, "Media/Profile/Photo.jpg")
+                current_chat.my_avatar = "Media/Profile/Photo.jpg"
+                current_chat.media_base = media_base_href(media_folder)
 
             # Process avatar images
             process_contact_avatars(current_chat, media_folder, contact_id)
@@ -234,7 +246,7 @@ def messages(db, data, media_folder, timezone_offset, filter_date, filter_chat, 
 
             # Ensure chat exists
             if contact_id not in data:
-                current_chat = data.add_chat(contact_id, ChatStore(Device.IOS))
+                current_chat = data.add_chat(contact_id, ChatStore(Device.IOS, media=media_folder))
                 process_contact_avatars(current_chat, media_folder, contact_id)
             else:
                 current_chat = data.get_chat(contact_id)
@@ -443,25 +455,35 @@ def media(db, data, media_folder, filter_date, filter_chat, filter_empty, separa
 
     # Process each media item
     mime = MimeTypes()
+    missing = 0
+    looked_up = 0
     with tqdm(total=total_row_number, desc="Processing media", unit="media", leave=False) as pbar:
         while (content := c.fetchone()) is not None:
-            process_media_item(content, data, media_folder, mime, separate_media, fix_dot_files,
-                               embed_exif, rename_media, timezone_offset)
+            looked_up += 1
+            if not process_media_item(content, data, media_folder, mime, separate_media, fix_dot_files,
+                                      embed_exif, rename_media, timezone_offset):
+                missing += 1
             pbar.update(1)
         total_time = pbar.format_dict['elapsed']
     logging.info(f"Processed {total_row_number} media in {convert_time_unit(total_time)}")
+    log_missing_media(missing, looked_up, media_folder, MEDIA_PATH_HINT)
 
 
 def process_media_item(content, data, media_folder, mime, separate_media, fix_dot_files=False,
                        embed_exif=False, rename_media=False, timezone_offset=0):
-    """Process a single media item."""
+    """
+    Process a single media item.
+
+    Returns:
+        bool: True if the media file was found on disk, False otherwise.
+    """
     file_path = f"{media_folder}/Message/{content['ZMEDIALOCALPATH']}"
     current_chat = data.get_chat(content["ZCONTACTJID"])
     message = current_chat.get_message(content["ZMESSAGE"])
     message.media = True
 
     if current_chat.media_base == "":
-        current_chat.media_base = media_folder + "/"
+        current_chat.media_base = media_base_href(media_folder)
 
     if os.path.isfile(file_path):
         # Set MIME type
@@ -506,16 +528,21 @@ def process_media_item(content, data, media_folder, mime, separate_media, fix_do
             )
         else:
             final_path = file_path
-        message.data = os.path.join(*final_path.split(os.sep)[1:])
+        message.data = to_media_relative_path(final_path, media_folder)
+        found = True
+
     else:
         # Handle missing media
         message.data = "The media is missing"
         message.mime = "media"
         message.meta = True
+        found = False
 
     # Add caption if available
     if content["ZTITLE"] is not None:
         message.caption = content["ZTITLE"]
+
+    return found
 
 
 def vcard(db, data, media_folder, filter_date, filter_chat, filter_empty):
@@ -562,13 +589,13 @@ def vcard(db, data, media_folder, filter_date, filter_chat, filter_empty):
     # Process each vCard
     with tqdm(total=total_row_number, desc="Processing vCards", unit="vcard", leave=False) as pbar:
         for content in contents:
-            process_vcard_item(content, path, data)
+            process_vcard_item(content, path, data, media_folder)
             pbar.update(1)
         total_time = pbar.format_dict['elapsed']
     logging.info(f"Processed {total_row_number} vCards in {convert_time_unit(total_time)}")
 
 
-def process_vcard_item(content, path, data):
+def process_vcard_item(content, path, data, media_folder):
     """Process a single vCard item."""
     file_paths = []
     vcard_names = content["ZVCARDNAME"].split("_$!<Name-Separator>!$_")
@@ -583,7 +610,7 @@ def process_vcard_item(content, path, data):
         file_name = "".join(x for x in name if x.isalnum())
         file_name = file_name.encode('utf-8')[:230].decode('utf-8', 'ignore')
         file_path = os.path.join(path, f"{file_name}.vcf")
-        file_paths.append(file_path)
+        file_paths.append(to_media_relative_path(file_path, media_folder))
 
         if not os.path.isfile(file_path):
             with open(file_path, "w", encoding="utf-8") as f:

--- a/Whatsapp_Chat_Exporter/utility.py
+++ b/Whatsapp_Chat_Exporter/utility.py
@@ -872,6 +872,87 @@ def safe_name(text: Union[str, bytes]) -> str:
     return "-".join(''.join(safe_chars).split())
 
 
+def media_folder_name(media_folder: str) -> str:
+    """
+    Return the name the media folder has inside the output directory.
+
+    The media folder is copied (or moved) into the output directory under its own
+    basename, so this is the name that output-relative links must be built on.
+
+    Args:
+        media_folder (str): The value of the --media option.
+
+    Returns:
+        str: The basename of the media folder.
+    """
+    return os.path.basename(os.path.normpath(media_folder))
+
+
+def media_base_href(media_folder: str) -> str:
+    """
+    Return the <base href> value for chats belonging to a media folder.
+
+    Args:
+        media_folder (str): The value of the --media option.
+
+    Returns:
+        str: An output-relative directory prefix, or "" when the media folder
+            resolves to the output directory itself.
+    """
+    name = media_folder_name(media_folder)
+    return f"{name}/" if name not in ("", ".", "..", os.sep) else ""
+
+
+def to_media_relative_path(path: str, media_folder: str) -> str:
+    """
+    Convert a filesystem path inside the media folder to a media-relative one.
+
+    Paths written into the HTML output are resolved by the browser against
+    <base href>, and paths written into the JSON output are documented as being
+    relative to media_base. Both therefore have to be relative to the media
+    folder, whether the user passed an absolute or a relative --media path.
+
+    Args:
+        path (str): A path to a file inside the media folder.
+        media_folder (str): The value of the --media option.
+
+    Returns:
+        str: The path relative to the media folder, using forward slashes.
+    """
+    return os.path.relpath(path, media_folder).replace(os.sep, "/")
+
+
+def log_missing_media(missing: int, looked_up: int, media_folder: str, hint: str) -> None:
+    """
+    Warn the user when media files referenced by the database are not on disk.
+
+    Without this, a completely wrong --media path is indistinguishable from a
+    successful run until the generated HTML is opened.
+
+    Args:
+        missing (int): Number of media files that could not be found on disk.
+        looked_up (int): Number of media files whose paths were checked. This is
+            lower than the reported media count, which also includes rows that do
+            not reference a local file at all.
+        media_folder (str): The value of the --media option.
+        hint (str): Platform specific advice on how to fix the --media path.
+    """
+    if missing == 0:
+        return
+    percentage = missing / looked_up * 100 if looked_up else 0
+    # A handful of missing files out of hundreds of thousands must not be rounded
+    # down to "0.0%", which would read as if nothing were missing at all.
+    shown = f"{percentage:.1f}%" if percentage >= 0.1 else "<0.1%"
+    logging.warning(
+        f"{missing} of the {looked_up} media files referenced by the database "
+        f'({shown}) were not found on disk and will be shown as '
+        f'"The media is missing" in the output.'
+    )
+    logging.warning(f"Media was looked up under: {os.path.abspath(media_folder)}")
+    if percentage > 50:
+        logging.warning(hint)
+
+
 def get_from_string(msg: Dict, chat_id: str) -> str:
     """Return the number or name for the sender"""
     if msg["from_me"]:

--- a/Whatsapp_Chat_Exporter/utility.py
+++ b/Whatsapp_Chat_Exporter/utility.py
@@ -922,6 +922,48 @@ def to_media_relative_path(path: str, media_folder: str) -> str:
     return os.path.relpath(path, media_folder).replace(os.sep, "/")
 
 
+# Subdirectories that identify a directory as a WhatsApp media folder. Each entry
+# is a sequence of path components; a folder is accepted if any of them is present.
+MEDIA_FOLDER_MARKERS = {
+    "android": (("Media",),),
+    "ios": (("Message", "Media"), ("Media", "Profile")),
+}
+
+
+def validate_media_folder(media_folder: str, device: str, hint: str) -> bool:
+    """
+    Warn early when --media does not point at a WhatsApp media folder.
+
+    A wrong --media path is otherwise only noticeable once the output is opened,
+    and because the vCard and thumbnail directories are created with parents=True,
+    it also causes directories to be fabricated at the wrong location.
+
+    Args:
+        media_folder (str): The value of the --media option.
+        device (str): The Device the export is for.
+        hint (str): Platform specific advice on how to fix the --media path.
+
+    Returns:
+        bool: True if the folder looks like a WhatsApp media folder.
+    """
+    absolute = os.path.abspath(media_folder)
+    if not os.path.isdir(media_folder):
+        logging.warning(f"The media folder does not exist: {absolute}")
+        logging.warning(hint)
+        return False
+
+    markers = MEDIA_FOLDER_MARKERS.get(device, ())
+    if markers and not any(os.path.isdir(os.path.join(media_folder, *marker)) for marker in markers):
+        expected = " or ".join("/".join(marker) for marker in markers)
+        logging.warning(
+            f"{absolute} does not look like a WhatsApp media folder: expected to find "
+            f"{expected} inside it. Media will most likely be missing from the output."
+        )
+        logging.warning(hint)
+        return False
+    return True
+
+
 def log_missing_media(missing: int, looked_up: int, media_folder: str, hint: str) -> None:
     """
     Warn the user when media files referenced by the database are not on disk.

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -420,3 +420,54 @@ class TestMediaPathHelpers:
     def test_log_missing_media_omits_hint_when_mostly_found(self, caplog):
         log_missing_media(1, 100, "WhatsApp", "check the path")
         assert "check the path" not in " ".join(r.getMessage() for r in caplog.records)
+
+
+class TestValidateMediaFolder:
+    """A wrong --media path should be reported before any work is done."""
+
+    def test_missing_folder_warns(self, tmp_path, caplog):
+        assert validate_media_folder(str(tmp_path / "nope"), "ios", "hint") is False
+        messages = " ".join(r.getMessage() for r in caplog.records)
+        assert "does not exist" in messages
+        assert "hint" in messages
+
+    def test_ios_folder_with_message_media_accepted(self, tmp_path, caplog):
+        (tmp_path / "Message" / "Media").mkdir(parents=True)
+        assert validate_media_folder(str(tmp_path), "ios", "hint") is True
+        assert caplog.records == []
+
+    def test_ios_folder_with_only_profile_accepted(self, tmp_path):
+        """A backup with profile pictures but no message media is still valid."""
+        (tmp_path / "Media" / "Profile").mkdir(parents=True)
+        assert validate_media_folder(str(tmp_path), "ios", "hint") is True
+
+    def test_ios_media_subfolder_rejected(self, tmp_path, caplog):
+        """Pointing --media at Message/Media is the common iOS mistake."""
+        media = tmp_path / "Message" / "Media"
+        media.mkdir(parents=True)
+        assert validate_media_folder(str(media), "ios", "check the path") is False
+        messages = " ".join(r.getMessage() for r in caplog.records)
+        assert "does not look like a WhatsApp media folder" in messages
+        assert "Message/Media or Media/Profile" in messages
+        assert "check the path" in messages
+
+    def test_ios_folder_with_stale_vcards_still_rejected(self, tmp_path):
+        """Debris left by an earlier wrong run must not make the path look valid."""
+        media = tmp_path / "Message" / "Media"
+        (media / "Message" / "vCards").mkdir(parents=True)
+        assert validate_media_folder(str(media), "ios", "hint") is False
+
+    def test_android_folder_accepted(self, tmp_path, caplog):
+        (tmp_path / "Media").mkdir()
+        assert validate_media_folder(str(tmp_path), "android", "hint") is True
+        assert caplog.records == []
+
+    def test_android_folder_rejected(self, tmp_path, caplog):
+        (tmp_path / "Databases").mkdir()
+        assert validate_media_folder(str(tmp_path), "android", "hint") is False
+        assert "expected to find Media inside it" in " ".join(
+            r.getMessage() for r in caplog.records)
+
+    def test_unknown_device_is_not_rejected(self, tmp_path):
+        """Only known layouts are checked; anything else is left alone."""
+        assert validate_media_folder(str(tmp_path), "exported", "hint") is True

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -350,3 +350,73 @@ class TestGetChatCondition:
         
         result = get_chat_condition(["user-name"], True, ["username"])
         assert result == "AND ( username LIKE '%user-name%')"
+
+
+class TestMediaPathHelpers:
+    """Output paths must be relative to the media folder for both absolute and
+    relative --media values, so that <base href> resolves them correctly."""
+
+    media_folder_name_cases = [
+        ("WhatsApp", "WhatsApp"),
+        ("WhatsApp/", "WhatsApp"),
+        ("/Volumes/Backup/AppDomainGroup-group.net.whatsapp.WhatsApp.shared",
+         "AppDomainGroup-group.net.whatsapp.WhatsApp.shared"),
+        ("/Volumes/Backup/AppDomainGroup-group.net.whatsapp.WhatsApp.shared/",
+         "AppDomainGroup-group.net.whatsapp.WhatsApp.shared"),
+        ("extracted/WhatsApp", "WhatsApp"),
+    ]
+
+    @pytest.mark.parametrize("media_folder, expected", media_folder_name_cases)
+    def test_media_folder_name(self, media_folder, expected):
+        assert media_folder_name(media_folder) == expected
+
+    def test_media_base_href_appends_separator(self):
+        assert media_base_href("/backup/WhatsApp") == "WhatsApp/"
+
+    def test_media_base_href_is_empty_for_current_directory(self):
+        assert media_base_href(".") == ""
+
+    to_relative_cases = [
+        # (media_folder, file path, expected output path)
+        ("WhatsApp", "WhatsApp/Message/Media/x@g.us/a/b/f.jpg", "Message/Media/x@g.us/a/b/f.jpg"),
+        ("/backup/shared", "/backup/shared/Message/Media/x@g.us/a/b/f.jpg",
+         "Message/Media/x@g.us/a/b/f.jpg"),
+        ("/backup/shared/", "/backup/shared/Media/Profile/123.thumb", "Media/Profile/123.thumb"),
+        ("nested/dir/WhatsApp", "nested/dir/WhatsApp/Message/vCards/n.vcf", "Message/vCards/n.vcf"),
+        ("/media with spaces/shared", "/media with spaces/shared/Message/Media/f.jpg",
+         "Message/Media/f.jpg"),
+    ]
+
+    @pytest.mark.parametrize("media_folder, path, expected", to_relative_cases)
+    def test_to_media_relative_path(self, media_folder, path, expected):
+        assert to_media_relative_path(path, media_folder) == expected
+
+    def test_absolute_and_relative_media_folders_agree(self):
+        """The same file must produce the same output path either way."""
+        relative = to_media_relative_path("WhatsApp/Message/Media/f.jpg", "WhatsApp")
+        absolute = to_media_relative_path("/backup/WhatsApp/Message/Media/f.jpg", "/backup/WhatsApp")
+        assert relative == absolute == "Message/Media/f.jpg"
+
+    def test_log_missing_media_silent_when_nothing_missing(self, caplog):
+        log_missing_media(0, 100, "WhatsApp", "hint")
+        assert caplog.records == []
+
+    def test_log_missing_media_warns_with_hint(self, caplog):
+        log_missing_media(100, 100, "WhatsApp", "check the path")
+        messages = [record.getMessage() for record in caplog.records]
+        assert all(record.levelname == "WARNING" for record in caplog.records)
+        assert "100 of the 100 media files" in messages[0]
+        assert "100.0%" in messages[0]
+        assert "check the path" in messages[-1]
+
+    def test_log_missing_media_does_not_round_a_few_files_down_to_zero(self, caplog):
+        """63 of 206582 is 0.03%, which must not be reported as "0.0%"."""
+        log_missing_media(63, 206582, "WhatsApp", "check the path")
+        message = caplog.records[0].getMessage()
+        assert "63 of the 206582 media files" in message
+        assert "(<0.1%)" in message
+        assert "0.0%" not in message
+
+    def test_log_missing_media_omits_hint_when_mostly_found(self, caplog):
+        log_missing_media(1, 100, "WhatsApp", "check the path")
+        assert "check the path" not in " ".join(r.getMessage() for r in caplog.records)


### PR DESCRIPTION
# Pre-flight Check

**All pull requests (excluding those with changes unrelated to source files) must target and branch off from the `dev` branch.**

Please select the applicable option below:

- [ ] This PR does not modify any source files (e.g., only updates the README).
- [x] This PR modifies one or more source files and targets the `dev` branch.

## Related Issue

- Partially addresses #178 — the doubled/mangled media paths described there are fixed; the feature request in that issue (sharing one Media folder between several output folders via `../Media`) is **not** implemented here.
- Related to #48 — fixes the avatar paths being emitted with a duplicated media folder prefix. The avatar *selection* problems reported in that issue (group avatar shown instead of the member's, older avatar preferred over the newest) are untouched.
- Relevant to #131 — with these changes, pre-creating a symlink named after the media folder inside the output directory makes the copy step a no-op, which achieves that request manually. No new option is added.

## Description of Changes

Three related fixes to iOS media path handling, kept as three separate commits so any one of them can be dropped or cherry-picked independently.

### 1. Emit media-relative output paths

Paths written into the output are resolved by the browser against `<base href="{{ media_base }}">`, but `process_media_item()` built them by stripping the first path component:

```python
message.data = os.path.join(*final_path.split(os.sep)[1:])
```

That yields a media-relative path only when `--media` is a single-segment relative path such as `WhatsApp`. Given an absolute `--media`, it strips just the leading separator, so `media_base` and `src` concatenate into a path that cannot exist:

```html
<base href="/Volumes/Backup/AppDomainGroup-group.net.whatsapp.WhatsApp.shared/">
<img src="Volumes/Backup/AppDomainGroup-group.net.whatsapp.WhatsApp.shared/Message/Media/….jpg">
```

Avatars and vCard links had the opposite problem: they kept the full media folder prefix and were then resolved against `<base href>` a second time, producing a doubled prefix. So the three kinds of output path disagreed with each other, and only one combination of them worked.

All output paths now go through `to_media_relative_path()`, and `media_base` is the media folder's basename — the name the media folder actually has once it is inside the output directory. Absolute and relative `--media` values now produce identical output.

`handle_media_directory()` used `os.path.join(args.output, args.media)`, which returns the *source* path unchanged when `args.media` is absolute. It therefore reported "WhatsApp directory already exists in output directory. Skipping..." and never copied anything. It now joins on the basename.

### 2. Warn when media files are not found

A wrong `--media` path produced no diagnostic at all: the run logged `Processed N media` and exited successfully, and the problem only became visible on opening the HTML. Both handlers now count media files that were not found on disk and warn with the directory that was searched, plus a platform-specific hint when the majority are missing:

```
[WARNING] 206582 of the 206582 media files referenced by the database (100.0%) were not found on disk and will be shown as "The media is missing" in the output.
[WARNING] Media was looked up under: /Volumes/Backup/…/Message/Media
[WARNING] For iOS/iPadOS, --media must point at the extracted app group directory that contains the "Message" and "Media" folders …
```

### 3. Count only media items that reference a local file

The iOS media count query used `WHERE 1=1` while the query that fetches the rows uses `WHERE ZMEDIALOCALPATH IS NOT NULL`. The reported total therefore included rows that are never processed: the progress bar could not reach 100%, and `Processed N media` overstated the work. On a 1.2M-message database the reported figure was 955,496 against 206,582 rows actually processed — 78% inflation.

The Android handler has an analogous divergence (count uses `WHERE 1=1`, both cursor variants filter on `jid.type <> 7`). I left it alone because there is no Android fixture database in the test suite to verify a change against.

### Startup validation

`validate_media_folder()` runs before any database work and warns when `--media` is missing or does not contain a recognisable layout (`Media/` for Android, `Message/Media` or `Media/Profile` for iOS). This matters beyond the diagnostics: the vCard and thumbnail directories are created with `parents=True` before anything is validated, so a wrong `--media` does not fail — it fabricates a directory tree and writes real files into it. Three wrong `--media` values left three sets of stray vCard directories inside an otherwise untouched raw iOS extraction.

Checking `Message/Media` rather than just `Message` is deliberate: a folder already polluted by an earlier wrong run contains `Message/<something>`, and a shallower check would accept the very path that caused the problem.

`process_contacts()` gained a matching warning. It tested `os.path.isfile()` with no `else` branch, so passing a directory to `--wa`, or a wrong filename, silently produced an export with no contact names and nothing in the log to explain it. This complements #215 / 8fa658c, which made the missing database non-fatal — this makes it visible.

The `--media` and `--wa` help text is updated to say what these options actually expect.

## Testing

- 24 new unit tests covering the path helpers and the validation, including the absolute-vs-relative equivalence and the stale-debris case.
- Full suite: 108 passed. The 5 failures on this branch are identical to the 5 that fail on unmodified `dev` in the same environment (`test_sanity_check` needs a compiled binary; the `determine_day` and `Timing` failures are timezone-dependent, and the latter is what #205 / #208 address).
- Verified end-to-end against a real 1.2M-message, 206k-media, 110 GB iOS extraction: media, avatars and vCard links all resolve from the output directory, with absolute and relative `--media` producing byte-identical HTML. Before the change the same export rendered every media item as "The media is missing" and every avatar link was doubled.

## Note for the maintainer

Two things I ran into that are **not** addressed here, to avoid mixing unrelated fixes into this PR:

1. `dev` currently crashes on any iOS contacts database containing a duplicated `ZWHATSAPPID`. `ios_handler.contacts()` calls `data.add_chat()` unconditionally, and `add_chat()` raises `ValueError: Chat ID already exists`. The database I tested against has 125 such duplicates out of 3,476 rows (one ID appears 8 times), which makes `dev` unusable for that export. It reproduces on unmodified `dev`, but works on `main`. I could not find an open issue for it. Happy to open one, or a separate PR, whichever you prefer.
2. The Android media count divergence described in section 3.
