### PR TITLE
Resolve LIDs in Android reaction senders and chats via jid_map

### DIFF
--- a/Whatsapp_Chat_Exporter/android_handler.py
+++ b/Whatsapp_Chat_Exporter/android_handler.py
@@ -522,13 +522,29 @@ def _get_reactions(db, data):
 
         logging.info("Processing reactions...", extra={"clear": True})
 
-        c.execute("""
+        # Resolve LIDs to phone number JIDs the same way messages are keyed (see get_jid_map_join),
+        # so reactors match message senders and reactions in LID-keyed chats are not dropped.
+        if data.get_system("jid_map_exists"):
+            sender_selection = "COALESCE(sender_pn.raw_string, jid.raw_string)"
+            chat_selection = "COALESCE(chat_pn.raw_string, chat_jid.raw_string)"
+            jid_map_join = """LEFT JOIN jid_map AS sender_map
+                    ON message_add_on.sender_jid_row_id = sender_map.lid_row_id
+                LEFT JOIN jid sender_pn
+                    ON sender_map.jid_row_id = sender_pn._id
+                LEFT JOIN jid_map AS chat_map
+                    ON chat.jid_row_id = chat_map.lid_row_id
+                LEFT JOIN jid chat_pn
+                    ON chat_map.jid_row_id = chat_pn._id"""
+        else:
+            sender_selection, chat_selection, jid_map_join = "jid.raw_string", "chat_jid.raw_string", ""
+
+        c.execute(f"""
             SELECT
                 message_add_on.parent_message_row_id,
                 message_add_on_reaction.reaction,
                 message_add_on.from_me,
-                jid.raw_string as sender_jid_raw,
-                chat_jid.raw_string as chat_jid_raw,
+                {sender_selection} as sender_jid_raw,
+                {chat_selection} as chat_jid_raw,
                 message_add_on_reaction.sender_timestamp
             FROM message_add_on
                 INNER JOIN message_add_on_reaction 
@@ -539,6 +555,7 @@ def _get_reactions(db, data):
                     ON message_add_on.chat_row_id = chat._id
                 LEFT JOIN jid chat_jid 
                     ON chat.jid_row_id = chat_jid._id
+                {jid_map_join}
         """)
     except sqlite3.OperationalError:
         logging.warning(f"Could not fetch reactions (schema might be too old or incompatible)")

--- a/tests/test_android_reactions.py
+++ b/tests/test_android_reactions.py
@@ -1,0 +1,73 @@
+import sqlite3
+
+import pytest
+
+from Whatsapp_Chat_Exporter.android_handler import _get_reactions
+from Whatsapp_Chat_Exporter.data_model import ChatCollection, ChatStore, Message
+from Whatsapp_Chat_Exporter.utility import Device
+
+# Minimal subset of the new msgstore.db schema used by _get_reactions.
+SCHEMA = """
+CREATE TABLE jid (_id INTEGER PRIMARY KEY, user TEXT, server TEXT, raw_string TEXT);
+CREATE TABLE jid_map (lid_row_id INTEGER, jid_row_id INTEGER);
+CREATE TABLE chat (_id INTEGER PRIMARY KEY, jid_row_id INTEGER);
+CREATE TABLE message_add_on (_id INTEGER PRIMARY KEY, chat_row_id INTEGER, parent_message_row_id INTEGER,
+                             from_me INTEGER, sender_jid_row_id INTEGER);
+CREATE TABLE message_add_on_reaction (message_add_on_row_id INTEGER, reaction TEXT, sender_timestamp INTEGER);
+"""
+
+GROUP_JID = "120363000000000000@g.us"
+PRIVATE_PN_JID = "15550002222@s.whatsapp.net"
+
+
+@pytest.fixture
+def db():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.executescript(SCHEMA)
+    db.executemany("INSERT INTO jid VALUES (?, ?, ?, ?)", [
+        (1, "120363000000000000", "g.us", GROUP_JID),
+        (2, "11111111111111", "lid", "11111111111111@lid"),  # group member, known by LID
+        (3, "15550001111", "s.whatsapp.net", "15550001111@s.whatsapp.net"),  # that member's phone number
+        (4, "22222222222222", "lid", "22222222222222@lid"),  # 1:1 chat stored under a LID
+        (5, "15550002222", "s.whatsapp.net", PRIVATE_PN_JID),  # that chat's phone number
+    ])
+    db.executemany("INSERT INTO jid_map VALUES (?, ?)", [(2, 3), (4, 5)])
+    db.executemany("INSERT INTO chat VALUES (?, ?)", [(10, 1), (11, 4)])
+    db.executemany("INSERT INTO message_add_on VALUES (?, ?, ?, ?, ?)", [
+        (100, 10, 1000, 0, 2),  # LID member reacts in the group
+        (101, 11, 1001, 0, 4),  # contact reacts in the LID-keyed 1:1 chat
+    ])
+    db.executemany("INSERT INTO message_add_on_reaction VALUES (?, ?, ?)", [(100, "👍", 0), (101, "❤️", 0)])
+    yield db
+    db.close()
+
+
+def _collection(jid_map_exists, private_chat_jid=PRIVATE_PN_JID):
+    """Chats keyed the way the message query keys them (phone number JID when jid_map resolves a LID)."""
+    data = ChatCollection()
+    data.set_system("jid_map_exists", jid_map_exists)
+    for chat_jid, message_id in ((GROUP_JID, 1000), (private_chat_jid, 1001)):
+        chat = data.add_chat(chat_jid, ChatStore(Device.ANDROID))
+        chat.add_message(message_id, Message(from_me=False, timestamp=1700000000, time=1700000000, key_id=message_id))
+    return data
+
+
+def test_reaction_sender_lid_resolved_to_phone_number(db):
+    data = _collection(jid_map_exists=True)
+    _get_reactions(db, data)
+    assert data[GROUP_JID].get_message(1000).reactions == {"15550001111": "👍"}
+
+
+def test_reaction_in_lid_keyed_chat_is_not_dropped(db):
+    data = _collection(jid_map_exists=True)
+    _get_reactions(db, data)
+    assert data[PRIVATE_PN_JID].get_message(1001).reactions == {"15550002222": "❤️"}
+
+
+def test_reactions_without_jid_map_table(db):
+    db.execute("DROP TABLE jid_map")
+    data = _collection(jid_map_exists=False, private_chat_jid="22222222222222@lid")
+    _get_reactions(db, data)
+    assert data[GROUP_JID].get_message(1000).reactions == {"11111111111111": "👍"}
+    assert data["22222222222222@lid"].get_message(1001).reactions == {"22222222222222": "❤️"}


### PR DESCRIPTION
# Pre-flight Check

**All pull requests (excluding those with changes unrelated to source files) must target and branch off from the `dev` branch.**

- [ ] This PR does not modify any source files (e.g., only updates the README).
- [x] This PR modifies one or more source files and targets the `dev` branch.

## Related Issue

- Follow-up to #188 (LID senders); possibly related to point 4 of #196 (missing emoji reactions).

## Description of Changes

**Problem.** Since #188, the Android message query resolves LID JIDs to phone number JIDs through `jid_map` (`get_jid_map_join()` / `get_jid_map_selection()`). `_get_reactions()` still reads the raw JIDs, so:

1. Reaction senders are keyed by LID, while the same people appear as phone numbers in `sender` of their own messages.
2. Reactions in chats whose own JID is a LID are silently dropped: the `ChatStore` is keyed by the phone number JID, but the reaction query looks the chat up by its LID JID, so `if chat_id and chat_id in data` is false.

**Change.** `_get_reactions()` applies the same resolution to the reaction sender JID and the chat JID: `COALESCE(<phone number JID via jid_map>, <raw JID>)`. The extra joins are only added when `data.get_system("jid_map_exists")` is true; older schemas run the original query.

**Tests.** New `tests/test_android_reactions.py` uses an in-memory minimal schema: (1) a LID reactor is resolved to the phone number, (2) a reaction in a LID-keyed chat is not dropped, (3) the no-`jid_map` path is unchanged. Tests 1 and 2 fail on current `dev` and pass with this change.

**Checked on a real backup** (counts only):

| | `dev` @ e966349 | with this PR |
|---|---:|---:|
| Reaction senders exported as phone number | 17,102 | 27,544 |
| Reaction senders left as LID although `jid_map` maps them | 10,442 | 0 |
| Reactions in LID-keyed one-to-one chats reaching the export | 0 of 2 | 2 of 2 |

Message output is unchanged. The full test suite shows no new failures; on my machine (Windows, UTC-4) five tests already fail on unmodified `dev` and appear to depend on the local time zone/platform (`TestDetermineDay` x3, `TestTiming::test_timing_none_offset`, `test_sanity_check`).

This is one of three independent PRs from the same investigation (reactions, @mentions, media MIME type); each applies on its own. I don't plan to follow up, so please feel free to edit, cherry-pick or close it as you see fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JPMpSaY4AkX5K2uo2FMwD
