### PR TITLE
Resolve @mentions of LIDs in Android message text

### DIFF
--- a/Whatsapp_Chat_Exporter/android_handler.py
+++ b/Whatsapp_Chat_Exporter/android_handler.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import logging
+import re
 import sqlite3
 import os
 import shutil
@@ -94,6 +95,8 @@ def messages(db, data, media_folder, timezone_offset, filter_date, filter_chat, 
             table_message = True
         except Exception as e:
             raise e
+
+    data.set_system("lid_map", _get_lid_map(db) if data.get_system("jid_map_exists") else {})
 
     with tqdm(total=total_row_number, desc="Processing messages", unit="msg", leave=False) as pbar:
         while (content := _fetch_row_safely(content_cursor)) is not None:
@@ -392,6 +395,11 @@ def _process_single_message(data, content, table_message, timezone_offset):
         # Real message
         _process_regular_message(message, content, table_message)
 
+    # Show @mentions of LIDs the same way as message senders
+    message.data = _resolve_mentions(message.data, data)
+    message.caption = _resolve_mentions(message.caption, data)
+    message.quoted_data = _resolve_mentions(message.quoted_data, data)
+
     current_chat.add_message(content["_id"], message)
 
 
@@ -505,6 +513,34 @@ def _format_message_text(text):
     if "\n" in text:
         text = text.replace("\n", " <br>")
     return text
+
+
+def _get_lid_map(db):
+    """Map LID users to their phone number JIDs using the jid_map table."""
+    c = db.cursor()
+    c.execute("""SELECT lid.user AS lid_user, pn.raw_string AS pn_jid
+                 FROM jid_map
+                    INNER JOIN jid lid
+                        ON jid_map.lid_row_id = lid._id
+                    INNER JOIN jid pn
+                        ON jid_map.jid_row_id = pn._id""")
+    return {row["lid_user"]: row["pn_jid"] for row in c.fetchall()}
+
+
+def _resolve_mentions(text, data):
+    """Replace @<LID> mentions in text with the contact name or phone number, as used for message senders."""
+    lid_map = data.get_system("lid_map")
+    if not isinstance(text, str) or not lid_map or "@" not in text:
+        return text
+
+    def replace(match):
+        pn_jid = lid_map.get(match.group(1))
+        if pn_jid is None:
+            return match.group(0)
+        name = data.get_chat(pn_jid).name if pn_jid in data else None
+        return "@" + (name or pn_jid.split("@")[0])
+
+    return re.sub(r"@(\d+)", replace, text)
 
 
 def _get_reactions(db, data):

--- a/tests/test_android_mentions.py
+++ b/tests/test_android_mentions.py
@@ -1,0 +1,51 @@
+import sqlite3
+
+import pytest
+
+from Whatsapp_Chat_Exporter.android_handler import _get_lid_map, _resolve_mentions
+from Whatsapp_Chat_Exporter.data_model import ChatCollection, ChatStore
+from Whatsapp_Chat_Exporter.utility import Device
+
+NAMED_PN_JID = "15550001111@s.whatsapp.net"
+UNNAMED_PN_JID = "15550002222@s.whatsapp.net"
+
+
+@pytest.fixture
+def data():
+    data = ChatCollection()
+    data.set_system("lid_map", {"11111111111111": NAMED_PN_JID, "22222222222222": UNNAMED_PN_JID})
+    data.add_chat(NAMED_PN_JID, ChatStore(Device.ANDROID, "Alice"))
+    return data
+
+
+def test_mention_resolved_to_contact_name(data):
+    assert _resolve_mentions("Hi @11111111111111, see above", data) == "Hi @Alice, see above"
+
+
+def test_mention_resolved_to_phone_number_without_contact_name(data):
+    assert _resolve_mentions("@22222222222222 thanks", data) == "@15550002222 thanks"
+
+
+def test_unknown_numbers_are_left_untouched(data):
+    text = "Call @33333333333333 or 11111111111111 before 10:00"
+    assert _resolve_mentions(text, data) == text
+
+
+def test_no_lid_map_or_no_text():
+    data = ChatCollection()
+    assert _resolve_mentions("Hi @11111111111111", data) == "Hi @11111111111111"
+    assert _resolve_mentions(None, data) is None
+
+
+def test_get_lid_map():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.executescript("""
+        CREATE TABLE jid (_id INTEGER PRIMARY KEY, user TEXT, server TEXT, raw_string TEXT);
+        CREATE TABLE jid_map (lid_row_id INTEGER, jid_row_id INTEGER);
+        INSERT INTO jid VALUES (1, '11111111111111', 'lid', '11111111111111@lid');
+        INSERT INTO jid VALUES (2, '15550001111', 's.whatsapp.net', '15550001111@s.whatsapp.net');
+        INSERT INTO jid_map VALUES (1, 2);
+    """)
+    assert _get_lid_map(db) == {"11111111111111": NAMED_PN_JID}
+    db.close()


### PR DESCRIPTION
# Pre-flight Check

**All pull requests (excluding those with changes unrelated to source files) must target and branch off from the `dev` branch.**

- [ ] This PR does not modify any source files (e.g., only updates the README).
- [x] This PR modifies one or more source files and targets the `dev` branch.

## Related Issue

- Follow-up to #188 (LID senders). No separate issue.

## Description of Changes

**Problem.** WhatsApp stores a mention inside the message text as `@<user>`, and on recent schemas `<user>` is usually a LID (e.g. `@123456789012345`). The app renders it as the person's name; the export keeps the raw LID, even though message senders are already resolved to phone numbers through `jid_map`.

**Change.**
- When `jid_map` exists, `messages()` builds a LID -> phone number JID map once (`_get_lid_map()`), stored as the `lid_map` system value.
- `_resolve_mentions()` rewrites `@<LID>` in `data`, `caption` and `quoted_data` to the contact name, or the phone number when no name is known, which is the same rule `_set_group_sender()` uses for senders.
- Only numbers that are known LIDs are replaced, so ordinary numbers in text are never touched. Without `jid_map` nothing changes.

**Tests.** New `tests/test_android_mentions.py`: mention resolved to a contact name, to a phone number, unknown numbers untouched, no map / no text, and `_get_lid_map()` on an in-memory schema.

**Checked on a real backup** (counts only): of 1,196 mentions, 584 were LIDs that `jid_map` maps; with this PR all 584 are shown as phone numbers (that backup has no contact names), and the one LID without a mapping stays as is. The full test suite shows no new failures (same five pre-existing, time zone/platform dependent failures on Windows as on unmodified `dev`).

This is one of three independent PRs from the same investigation (reactions, @mentions, media MIME type); each applies on its own. I don't plan to follow up, so please feel free to edit, cherry-pick or close it as you see fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JPMpSaY4AkX5K2uo2FMwD
